### PR TITLE
Update to version 0.4.0 from central-publishing-maven-plugin-0.4.0-sources.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.sonatype.central</groupId>
   <artifactId>central-publishing-maven-plugin</artifactId>
-  <version>0.3.1</version>
+  <version>0.4.0</version>
   <packaging>maven-plugin</packaging>
 
   <name>Central Publishing Maven Plugin</name>
@@ -47,11 +47,6 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>org.sonatype.central</groupId>
-      <artifactId>central-publishing-client</artifactId>
-      <version>1.4.0</version>
-    </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
@@ -108,9 +103,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.3.1</version>
+      <version>4.8.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -118,6 +119,22 @@
       <artifactId>mockserver-client-java</artifactId>
       <version>5.15.0</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.16.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <version>5.3.1</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>commons-logging</artifactId>
+          <groupId>commons-logging</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 
@@ -424,9 +441,6 @@
                 </goals>
               </execution>
             </executions>
-            <configuration>
-              <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
-            </configuration>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/sonatype/central/publisher/client/PublisherClient.java
+++ b/src/main/java/org/sonatype/central/publisher/client/PublisherClient.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client;
+
+import java.nio.file.Path;
+
+import org.sonatype.central.publisher.client.httpclient.auth.AuthProvider;
+import org.sonatype.central.publisher.client.httpclient.auth.AuthProviderType;
+import org.sonatype.central.publisher.client.httpclient.utils.PublisherBundle;
+import org.sonatype.central.publisher.client.model.DeploymentApiResponse;
+import org.sonatype.central.publisher.client.model.PublishingType;
+
+public interface PublisherClient
+{
+  PublisherBundle compose(final Path sourceDir, final String bundleFileName);
+
+  PublisherBundle compose(final Path sourceDir, final Path destDir, final String bundleFileName);
+
+  PublisherBundle.BundleBuilder getBuilder(final Path sourceDir);
+
+  String upload(final String name, final Path body, final PublishingType publishingType);
+
+  DeploymentApiResponse status(final String deploymentId);
+
+  boolean isPublished(final String namespace, final String name, final String version);
+
+  /**
+   * For auth providers whose principal is not a userId
+   */
+  AuthProvider setAuthProvider(
+      final AuthProviderType authProviderType,
+      final String organizationId,
+      final String userId,
+      final String principal,
+      final String credential);
+
+  /**
+   * For auth providers whose principal is a userId
+   */
+  default AuthProvider setAuthProvider(
+      final AuthProviderType authProviderType,
+      final String organizationId,
+      final String principal,
+      final String credential)
+  {
+    return setAuthProvider(authProviderType, organizationId, principal, principal, credential);
+  }
+
+  void setCentralBaseUrl(final String centralBaseUrl);
+}

--- a/src/main/java/org/sonatype/central/publisher/client/PublisherClientFactory.java
+++ b/src/main/java/org/sonatype/central/publisher/client/PublisherClientFactory.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client;
+
+import org.sonatype.central.publisher.client.httpclient.ComponentPublishedEndpoint;
+import org.sonatype.central.publisher.client.httpclient.StatusPublisherEndpoint;
+import org.sonatype.central.publisher.client.httpclient.UploadPublisherEndpoint;
+import org.sonatype.central.publisher.client.httpclient.auth.AuthProviderFactory;
+
+public final class PublisherClientFactory
+{
+  private PublisherClientFactory() {
+  }
+
+  public static PublisherClient createPublisherClient() {
+    return new PublisherClientImpl(new UploadPublisherEndpoint(), new StatusPublisherEndpoint(),
+        new ComponentPublishedEndpoint(), new AuthProviderFactory());
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/client/PublisherClientImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/client/PublisherClientImpl.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.sonatype.central.publisher.client.httpclient.ComponentPublishedEndpoint;
+import org.sonatype.central.publisher.client.httpclient.StatusPublisherEndpoint;
+import org.sonatype.central.publisher.client.httpclient.UploadPublisherEndpoint;
+import org.sonatype.central.publisher.client.httpclient.auth.AuthProvider;
+import org.sonatype.central.publisher.client.httpclient.auth.AuthProviderFactory;
+import org.sonatype.central.publisher.client.httpclient.auth.AuthProviderType;
+import org.sonatype.central.publisher.client.httpclient.utils.PublisherBundle;
+import org.sonatype.central.publisher.client.httpclient.utils.PublisherBundle.BundleBuilder;
+import org.sonatype.central.publisher.client.model.DeploymentApiResponse;
+import org.sonatype.central.publisher.client.model.PublishingType;
+
+import static org.sonatype.central.publisher.client.PublisherConstants.COMPONENT_NAMESPACE_QUERY_PARAM;
+import static org.sonatype.central.publisher.client.PublisherConstants.COMPONENT_NAME_QUERY_PARAM;
+import static org.sonatype.central.publisher.client.PublisherConstants.COMPONENT_VERSION_QUERY_PARAM;
+import static org.sonatype.central.publisher.client.PublisherConstants.DEFAULT_CENTRAL_BASEURL;
+import static org.sonatype.central.publisher.client.PublisherConstants.DEPLOYMENT_ID_QUERY_PARAM;
+import static org.sonatype.central.publisher.client.PublisherConstants.DEPLOYMENT_NAME_QUERY_PARAM;
+import static org.sonatype.central.publisher.client.PublisherConstants.DEPLOYMENT_PUBLISHING_TYPE_QUERY_PARAM;
+
+class PublisherClientImpl
+    implements PublisherClient
+{
+  private String centralBaseUrl;
+
+  private AuthProvider authProvider;
+
+  private final UploadPublisherEndpoint uploadPublisherEndpoint;
+
+  private final StatusPublisherEndpoint statusPublisherEndpoint;
+
+  private final ComponentPublishedEndpoint componentPublishedEndpoint;
+
+  private final AuthProviderFactory authProviderFactory;
+
+  public PublisherClientImpl(
+      final UploadPublisherEndpoint uploadPublisherEndpoint,
+      final StatusPublisherEndpoint statusPublisherEndpoint,
+      final ComponentPublishedEndpoint componentPublishedEndpoint,
+      final AuthProviderFactory authProviderFactory)
+  {
+    this.uploadPublisherEndpoint = uploadPublisherEndpoint;
+    this.statusPublisherEndpoint = statusPublisherEndpoint;
+    this.componentPublishedEndpoint = componentPublishedEndpoint;
+    this.authProviderFactory = authProviderFactory;
+  }
+
+  @Override
+  public PublisherBundle compose(final Path sourceDir, final String bundleFileName) {
+    return new BundleBuilder(sourceDir).bundleName(bundleFileName).addAllSourceFiles().build();
+  }
+
+  @Override
+  public PublisherBundle compose(final Path sourceDir, final Path destDir, final String bundleFileName) {
+    return new BundleBuilder(sourceDir).destPath(destDir).bundleName(bundleFileName).addAllSourceFiles()
+        .build();
+  }
+
+  @Override
+  public BundleBuilder getBuilder(final Path sourceDir) {
+    return new BundleBuilder(sourceDir);
+  }
+
+  @Override
+  public String upload(final String name, final Path body, final PublishingType publishingType) {
+    Map<String, String> queryParams = authProvider().getQueryParams();
+    queryParams.put(DEPLOYMENT_NAME_QUERY_PARAM, name);
+    queryParams.put(DEPLOYMENT_PUBLISHING_TYPE_QUERY_PARAM, publishingType.name());
+    return uploadPublisherEndpoint.call(centralBaseUrl(), authProvider(), queryParams, body);
+  }
+
+  @Override
+  public DeploymentApiResponse status(final String deploymentId) {
+    Map<String, String> queryParams = authProvider().getQueryParams();
+    queryParams.put(DEPLOYMENT_ID_QUERY_PARAM, deploymentId);
+    return statusPublisherEndpoint.call(centralBaseUrl(), authProvider(), queryParams);
+  }
+
+  @Override
+  public boolean isPublished(final String namespace, final String name, final String version) {
+    Map<String, String> queryParams = authProvider().getQueryParams();
+    queryParams.put(COMPONENT_NAMESPACE_QUERY_PARAM, namespace);
+    queryParams.put(COMPONENT_NAME_QUERY_PARAM, name);
+    queryParams.put(COMPONENT_VERSION_QUERY_PARAM, version);
+    return componentPublishedEndpoint.call(centralBaseUrl(), authProvider(), queryParams);
+  }
+
+  @Override
+  public AuthProvider setAuthProvider(
+      final AuthProviderType authProviderType,
+      final String organizationId,
+      final String userId,
+      final String principal,
+      final String credential)
+  {
+    authProvider = authProviderFactory.get(authProviderType, organizationId, userId, principal, credential);
+    return authProvider;
+  }
+
+  private AuthProvider authProvider() {
+    if (authProvider == null) {
+      throw new IllegalStateException("An AuthProvider has not been set!");
+    }
+    return authProvider;
+  }
+
+  @Override
+  public void setCentralBaseUrl(final String centralBaseUrl) {
+    this.centralBaseUrl = centralBaseUrl;
+  }
+
+  private String centralBaseUrl() {
+    return centralBaseUrl != null ? centralBaseUrl : DEFAULT_CENTRAL_BASEURL;
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/client/PublisherConstants.java
+++ b/src/main/java/org/sonatype/central/publisher/client/PublisherConstants.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+
+package org.sonatype.central.publisher.client;
+
+public class PublisherConstants
+{
+  public static final String DEFAULT_CENTRAL_BASEURL = "https://central.sonatype.com";
+
+  public static final String STATUS_ENDPOINT_URL = "/api/v1/publisher/status";
+
+  public static final String UPLOAD_ENDPOINT_URL = "/api/v1/publisher/upload";
+
+  public static final String PUBLISHED_ENDPOINT_URL = "/api/v1/publisher/published";
+
+  public static final String HTTP_AUTHORIZATION_HEADER = "Authorization";
+
+  public static final String HTTP_BASIC_AUTH_SCHEME = "Basic";
+
+  public static final String HTTP_USERTOKEN_AUTH_SCHEME = "UserToken";
+
+  public static final String ORGANIZATION_ID_QUERY_PARAM = "orgId";
+
+  public static final String USER_ID_QUERY_PARAM = "userId";
+
+  public static final String DEPLOYMENT_NAME_QUERY_PARAM = "name";
+
+  public static final String DEPLOYMENT_ID_QUERY_PARAM = "id";
+
+  public static final String DEPLOYMENT_PUBLISHING_TYPE_QUERY_PARAM = "publishingType";
+
+  public static final String DEFAULT_ORGANIZATION_ID = "org";
+
+  public static final String COMPONENT_NAMESPACE_QUERY_PARAM = "namespace";
+
+  public static final String COMPONENT_NAME_QUERY_PARAM = "name";
+
+  public static final String COMPONENT_VERSION_QUERY_PARAM = "version";
+}

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/ComponentPublishedEndpoint.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/ComponentPublishedEndpoint.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client.httpclient;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.sonatype.central.publisher.client.httpclient.auth.AuthProvider;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hc.client5.http.HttpResponseException;
+
+import static org.sonatype.central.publisher.client.PublisherConstants.PUBLISHED_ENDPOINT_URL;
+import static org.sonatype.central.publisher.client.httpclient.PublisherHttpClient.sendRequest;
+import static org.sonatype.central.publisher.client.httpclient.utils.HttpResponseUtil.toContentString;
+
+public class ComponentPublishedEndpoint
+{
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  public boolean call(
+      final String baseUrl,
+      final AuthProvider authProvider,
+      final Map<String, String> params)
+  {
+    try {
+      String response = sendRequest(authProvider, baseUrl + PUBLISHED_ENDPOINT_URL, params, null, RequestType.GET);
+      Map<String, Boolean> result = objectMapper.readValue(response, new TypeReference<HashMap<String, Boolean>>() { });
+      return result.get("published");
+    }
+    catch (HttpResponseException e) {
+      throw new RuntimeException("Cannot get component published status. Response status code: "
+          + e.getStatusCode()
+          + " response message: "
+          + toContentString(e));
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/PublisherHttpClient.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/PublisherHttpClient.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+
+package org.sonatype.central.publisher.client.httpclient;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.sonatype.central.publisher.client.httpclient.auth.AuthProvider;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.entity.mime.HttpMultipartMode;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.impl.classic.BasicHttpClientResponseHandler;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.net.URIBuilder;
+
+public class PublisherHttpClient
+{
+  public static String sendRequest(
+      final AuthProvider authProvider,
+      final String endpointUrl,
+      final Map<String, String> params,
+      final Path body,
+      final RequestType requestType) throws IOException
+  {
+    try {
+      URIBuilder uriBuilder = new URIBuilder(endpointUrl);
+      params.forEach(uriBuilder::addParameter);
+
+      switch (requestType) {
+        case POST: {
+          HttpPost httpPost = new HttpPost(uriBuilder.build());
+          authProvider.getAuthHeaders().forEach(httpPost::addHeader);
+
+          if (body != null) {
+            File file = body.toFile();
+            MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+            builder.setMode(HttpMultipartMode.LEGACY);
+            builder.addBinaryBody("bundle", file, ContentType.APPLICATION_OCTET_STREAM, file.getName());
+            httpPost.setEntity(builder.build());
+          }
+
+          try (CloseableHttpClient client = HttpClients.createDefault()) {
+            return client.execute(httpPost, new BasicHttpClientResponseHandler());
+          }
+        }
+        case GET:
+        default: {
+          HttpGet httpGet = new HttpGet(uriBuilder.build());
+          authProvider.getAuthHeaders().forEach(httpGet::addHeader);
+          try (CloseableHttpClient client = HttpClients.createDefault()) {
+            return client.execute(httpGet, new BasicHttpClientResponseHandler());
+          }
+        }
+      }
+    }
+    catch (URISyntaxException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/RequestType.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/RequestType.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+
+package org.sonatype.central.publisher.client.httpclient;
+
+public enum RequestType
+{
+  POST, GET
+}

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/StatusPublisherEndpoint.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/StatusPublisherEndpoint.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client.httpclient;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.sonatype.central.publisher.client.httpclient.auth.AuthProvider;
+import org.sonatype.central.publisher.client.model.DeploymentApiResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hc.client5.http.HttpResponseException;
+
+import static org.sonatype.central.publisher.client.PublisherConstants.STATUS_ENDPOINT_URL;
+import static org.sonatype.central.publisher.client.httpclient.PublisherHttpClient.sendRequest;
+import static org.sonatype.central.publisher.client.httpclient.utils.HttpResponseUtil.toContentString;
+
+public class StatusPublisherEndpoint
+{
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  public DeploymentApiResponse call(
+      final String baseUrl,
+      final AuthProvider authProvider,
+      final Map<String, String> params)
+  {
+    try {
+      String response = sendRequest(authProvider, baseUrl + STATUS_ENDPOINT_URL, params, null, RequestType.POST);
+      return objectMapper.readValue(response, DeploymentApiResponse.class);
+    }
+    catch (HttpResponseException e) {
+      throw new RuntimeException("Cannot get deployment status. Response status code: "
+          + e.getStatusCode()
+          + " response message: "
+          + toContentString(e));
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/UploadPublisherEndpoint.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/UploadPublisherEndpoint.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client.httpclient;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.sonatype.central.publisher.client.httpclient.auth.AuthProvider;
+
+import org.apache.hc.client5.http.HttpResponseException;
+
+import static org.sonatype.central.publisher.client.PublisherConstants.UPLOAD_ENDPOINT_URL;
+import static org.sonatype.central.publisher.client.httpclient.PublisherHttpClient.sendRequest;
+import static org.sonatype.central.publisher.client.httpclient.RequestType.POST;
+import static org.sonatype.central.publisher.client.httpclient.utils.HttpResponseUtil.toContentString;
+
+public class UploadPublisherEndpoint
+{
+  public String call(
+      final String baseUrl,
+      final AuthProvider authProvider,
+      final Map<String, String> params,
+      final Path body)
+  {
+    try {
+      return sendRequest(authProvider, baseUrl + UPLOAD_ENDPOINT_URL, params, body, POST);
+    }
+    catch (HttpResponseException e) {
+      throw new RuntimeException(
+          "Invalid request. Status: " + e.getStatusCode() + " Response body: " + toContentString(e));
+    }
+    catch (IOException e) {
+      throw new RuntimeException("Invalid request. " + e.getMessage());
+    }
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/auth/AbstractAuthProvider.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/auth/AbstractAuthProvider.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client.httpclient.auth;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.sonatype.central.publisher.client.PublisherConstants.HTTP_AUTHORIZATION_HEADER;
+import static org.sonatype.central.publisher.client.PublisherConstants.ORGANIZATION_ID_QUERY_PARAM;
+import static org.sonatype.central.publisher.client.PublisherConstants.USER_ID_QUERY_PARAM;
+
+public abstract class AbstractAuthProvider
+    implements AuthProvider
+{
+  private final Map<String, String> headers = new HashMap<>();
+
+  private final Map<String, String> queryParams = new HashMap<>();
+
+  private final String organizationId;
+
+  private final String userId;
+
+  private final String principal;
+
+  private final String credential;
+
+  protected AbstractAuthProvider(
+      final String organizationId,
+      final String userId,
+      final String principal,
+      final String credential)
+  {
+    headers.put(HTTP_AUTHORIZATION_HEADER, buildAuthorizationHeaderValue(principal, credential));
+    queryParams.put(ORGANIZATION_ID_QUERY_PARAM, organizationId);
+    queryParams.put(USER_ID_QUERY_PARAM, userId);
+    this.organizationId = organizationId;
+    this.userId = userId;
+    this.principal = principal;
+    this.credential = credential;
+  }
+
+  @Override
+  public Map<String, String> getAuthHeaders() {
+    return new HashMap<>(headers);
+  }
+
+  @Override
+  public Map<String, String> getQueryParams() {
+    return queryParams;
+  }
+
+  @Override
+  public String getOrganizationId() {
+    return organizationId;
+  }
+
+  @Override
+  public String getUserId() {
+    return userId;
+  }
+
+  @Override
+  public String getPrincipal() {
+    return principal;
+  }
+
+  @Override
+  public String getCredential() {
+    return credential;
+  }
+
+  private String buildAuthorizationHeaderValue(String principal, String credential) {
+    String value = principal + ":" + credential;
+    return getAuthScheme() + " " + Base64.getEncoder().encodeToString(value.getBytes());
+  }
+
+  protected abstract String getAuthScheme();
+}

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/auth/AuthProvider.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/auth/AuthProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client.httpclient.auth;
+
+import java.util.Map;
+
+public interface AuthProvider
+{
+  Map<String, String> getAuthHeaders();
+
+  Map<String, String> getQueryParams();
+
+  String getOrganizationId();
+
+  String getUserId();
+
+  String getPrincipal();
+
+  String getCredential();
+}

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/auth/AuthProviderFactory.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/auth/AuthProviderFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client.httpclient.auth;
+
+public class AuthProviderFactory
+{
+  public AuthProvider get(
+      final AuthProviderType authProviderType,
+      final String organizationId,
+      final String userId,
+      final String principal,
+      final String credential)
+  {
+    if (authProviderType == null) {
+      throw new IllegalArgumentException("Must provide a valid authProviderType for authentication!");
+    }
+    if (organizationId == null) {
+      throw new IllegalArgumentException("Must provide a valid organizationId for authentication!");
+    }
+    if (userId == null) {
+      throw new IllegalArgumentException("Must provide a valid userId for authentication!");
+    }
+    if (principal == null) {
+      throw new IllegalArgumentException("Must provide a valid principal for authentication!");
+    }
+    if (credential == null) {
+      throw new IllegalArgumentException("Must provide a valid credential for authentication!");
+    }
+
+    switch (authProviderType) {
+      case BASIC:
+        return new BasicAuthProvider(organizationId, principal, credential);
+      case USERTOKEN:
+        return new UserTokenAuthProvider(organizationId, userId, principal, credential);
+    }
+
+    throw new IllegalStateException(
+        "Must provide a valid AuthProviderType {" + authProviderType.name() + "} for authentication!");
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/auth/AuthProviderType.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/auth/AuthProviderType.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client.httpclient.auth;
+
+public enum AuthProviderType
+{
+  BASIC,
+  USERTOKEN
+}

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/auth/BasicAuthProvider.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/auth/BasicAuthProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client.httpclient.auth;
+
+import static org.sonatype.central.publisher.client.PublisherConstants.HTTP_BASIC_AUTH_SCHEME;
+
+/**
+ * An AuthProvider that will add the Authorization header to the request, using the Basic AuthScheme as needed by
+ * Central's Basic authentication implementation
+ */
+public class BasicAuthProvider
+    extends AbstractAuthProvider
+{
+  public BasicAuthProvider(final String organizationId, final String username, final String password) {
+    super(organizationId, username, username, password);
+  }
+
+  @Override
+  protected String getAuthScheme() {
+    return HTTP_BASIC_AUTH_SCHEME;
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/auth/UserTokenAuthProvider.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/auth/UserTokenAuthProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client.httpclient.auth;
+
+import static org.sonatype.central.publisher.client.PublisherConstants.HTTP_USERTOKEN_AUTH_SCHEME;
+
+/**
+ * An AuthProvider that will add the Authorization header to the request, using the UserToken AuthScheme as needed by
+ * Central's UserToken authentication implementation
+ */
+public class UserTokenAuthProvider
+    extends AbstractAuthProvider
+{
+  public UserTokenAuthProvider(
+      final String organizationId,
+      final String userId,
+      final String nameCode,
+      final String passCode)
+  {
+    super(organizationId, userId, nameCode, passCode);
+  }
+
+  @Override
+  protected String getAuthScheme() {
+    return HTTP_USERTOKEN_AUTH_SCHEME;
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/utils/HttpResponseUtil.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/utils/HttpResponseUtil.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client.httpclient.utils;
+
+import org.apache.hc.client5.http.HttpResponseException;
+
+public class HttpResponseUtil
+{
+  private HttpResponseUtil() {
+
+  }
+
+  public static String toContentString(HttpResponseException e) {
+    byte[] contentBytes = e.getContentBytes();
+    return contentBytes != null ? new String(contentBytes) : "";
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/utils/PublisherBundle.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/utils/PublisherBundle.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+
+package org.sonatype.central.publisher.client.httpclient.utils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.apache.commons.io.IOUtils;
+
+import static java.util.stream.Collectors.toSet;
+import static org.sonatype.central.publisher.client.utils.PathUtils.PathOf;
+
+public class PublisherBundle
+{
+  private final String name;
+
+  private final Path path;
+
+  private Set<Path> files = new HashSet<>();
+
+  public PublisherBundle(final String name, final Path path) {
+    this.name = name;
+    this.path = path;
+  }
+
+  private PublisherBundle(final BundleBuilder bundleBuilder) {
+    this.name = bundleBuilder.bundleName;
+    this.path = bundleBuilder.bundlePath;
+    this.files = bundleBuilder.files;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Path getPath() {
+    return path;
+  }
+
+  public List<Path> getFiles() {
+    return new ArrayList<>(files);
+  }
+
+  public static class BundleBuilder
+  {
+    private Path sourcePath;
+
+    private Path destPath;
+
+    private Path bundlePath;
+
+    private String bundleName;
+
+    private final Set<Path> files;
+
+    public BundleBuilder(final Path sourcePath) {
+      this.sourcePath = sourcePath;
+      this.destPath = sourcePath;
+      this.bundleName = "bundle.zip";
+      this.files = new HashSet<>();
+    }
+
+    public BundleBuilder sourcePath(Path sourcePath) {
+      this.sourcePath = sourcePath;
+      return this;
+    }
+
+    public BundleBuilder destPath(Path destPath) {
+      this.destPath = destPath;
+      return this;
+    }
+
+    public BundleBuilder bundleName(String bundleName) {
+      this.bundleName = bundleName;
+      return this;
+    }
+
+    public BundleBuilder add(Path filePath) {
+      this.files.add(filePath);
+      return this;
+    }
+
+    public BundleBuilder addAll(Set<Path> files) {
+      this.files.addAll(files);
+      return this;
+    }
+
+    public BundleBuilder addAllSourceFiles() {
+      Set<Path> files;
+      try (Stream<Path> paths = Files.walk(this.sourcePath)) {
+        files = paths.filter(path -> path.toFile().isFile()).collect(toSet());
+        this.files.addAll(files);
+      }
+      catch (IOException e) {
+        throw new RuntimeException("Error on source dir traversal", e);
+      }
+      return this;
+    }
+
+    public PublisherBundle build() {
+      this.bundlePath = createBundle();
+      return new PublisherBundle(this);
+    }
+
+    private Path createBundle() {
+      Path newBundle = PathOf(this.destPath.toString(), this.bundleName);
+
+      try {
+        Files.createDirectories(newBundle.getParent());
+        Files.deleteIfExists(newBundle);
+        Files.createFile(newBundle);
+      }
+      catch (IOException e) {
+        throw new RuntimeException("File already exists: " + newBundle);
+      }
+      try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(newBundle.toFile()))) {
+        for (Path filePath : this.files) {
+          Path fileRelativePath = this.sourcePath.relativize(filePath);
+          File bundleEntry = filePath.toFile();
+
+          if (bundleEntry.isFile()) {
+            zipOutputStream.putNextEntry(new ZipEntry(fileRelativePath.toString()));
+            try (FileInputStream in = new FileInputStream(bundleEntry)) {
+              IOUtils.copy(in, zipOutputStream);
+            }
+
+            zipOutputStream.closeEntry();
+          }
+        }
+
+        zipOutputStream.finish();
+      }
+      catch (Exception e) {
+        throw new RuntimeException("Error on bundle creation", e);
+      }
+
+      return newBundle;
+    }
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/client/model/DeploymentApiResponse.java
+++ b/src/main/java/org/sonatype/central/publisher/client/model/DeploymentApiResponse.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+
+package org.sonatype.central.publisher.client.model;
+
+import java.util.List;
+import java.util.Map;
+
+public class DeploymentApiResponse
+{
+  private String deploymentId;
+
+  private String deploymentName;
+
+  private DeploymentState deploymentState;
+
+  private List<String> purls;
+
+  private Map<String, List<String>> errors;
+
+  private String cherryBomUrl;
+
+  public String getDeploymentId() {
+    return deploymentId;
+  }
+
+  public void setDeploymentId(final String deploymentId) {
+    this.deploymentId = deploymentId;
+  }
+
+  public String getDeploymentName() {
+    return deploymentName;
+  }
+
+  public void setDeploymentName(final String deploymentName) {
+    this.deploymentName = deploymentName;
+  }
+
+  public DeploymentState getDeploymentState() {
+    return deploymentState;
+  }
+
+  public void setDeploymentState(final DeploymentState deploymentState) {
+    this.deploymentState = deploymentState;
+  }
+
+  public List<String> getPurls() {
+    return purls;
+  }
+
+  public void setPurls(final List<String> purls) {
+    this.purls = purls;
+  }
+
+  public Map<String, List<String>> getErrors() {
+    return errors;
+  }
+
+  public void setErrors(final Map<String, List<String>> errors) {
+    this.errors = errors;
+  }
+
+  public String getCherryBomUrl() {
+    return cherryBomUrl;
+  }
+
+  public void setCherryBomUrl(final String cherryBomUrl) {
+    this.cherryBomUrl = cherryBomUrl;
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/client/model/DeploymentState.java
+++ b/src/main/java/org/sonatype/central/publisher/client/model/DeploymentState.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+
+package org.sonatype.central.publisher.client.model;
+
+public enum DeploymentState
+{
+  PENDING,
+  VALIDATING,
+  VALIDATED,
+  PUBLISHING,
+  PUBLISHED,
+  FAILED
+}

--- a/src/main/java/org/sonatype/central/publisher/client/model/PublishingType.java
+++ b/src/main/java/org/sonatype/central/publisher/client/model/PublishingType.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+
+package org.sonatype.central.publisher.client.model;
+
+public enum PublishingType
+{
+  USER_MANAGED,
+  AUTOMATIC
+}

--- a/src/main/java/org/sonatype/central/publisher/client/utils/PathUtils.java
+++ b/src/main/java/org/sonatype/central/publisher/client/utils/PathUtils.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client.utils;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+
+public class PathUtils
+{
+  private PathUtils() {
+  }
+
+  public static Path PathOf(final String first, final String... more) {
+    return FileSystems.getDefault().getPath(first, more);
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/plugin/published/ComponentPublishedCheckerImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/published/ComponentPublishedCheckerImpl.java
@@ -5,8 +5,6 @@
 
 package org.sonatype.central.publisher.plugin.published;
 
-import java.util.Objects;
-
 import org.sonatype.central.publisher.client.PublisherClient;
 import org.sonatype.central.publisher.client.PublisherClientFactory;
 
@@ -27,8 +25,7 @@ public class ComponentPublishedCheckerImpl
   }
 
   public ComponentPublishedCheckerImpl(final PublisherClient publisherClient) {
-    this.publisherClient =
-        Objects.requireNonNullElseGet(publisherClient, PublisherClientFactory::createPublisherClient);
+    this.publisherClient = publisherClient != null ? publisherClient : PublisherClientFactory.createPublisherClient();
     if (this.getLogger() == null) {
       this.enableLogging(new ConsoleLogger());
     }

--- a/src/main/java/org/sonatype/central/publisher/plugin/uploader/ArtifactUploaderImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/uploader/ArtifactUploaderImpl.java
@@ -15,7 +15,6 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 
 import static java.lang.String.format;
-import static java.util.Objects.requireNonNullElseGet;
 
 @Component(role = ArtifactUploader.class)
 public class ArtifactUploaderImpl
@@ -29,7 +28,7 @@ public class ArtifactUploaderImpl
   public ArtifactUploaderImpl() { }
 
   ArtifactUploaderImpl(final PublisherClient publisherClient) {
-    this.publisherClient = requireNonNullElseGet(publisherClient, PublisherClientFactory::createPublisherClient);
+    this.publisherClient = publisherClient != null ? publisherClient : PublisherClientFactory.createPublisherClient();
   }
 
   @Override

--- a/src/main/java/org/sonatype/central/publisher/plugin/utils/MojoUtilsImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/utils/MojoUtilsImpl.java
@@ -5,6 +5,7 @@
 package org.sonatype.central.publisher.plugin.utils;
 
 import java.io.File;
+import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -98,7 +99,9 @@ public class MojoUtilsImpl
       return new File(firstWithThisMojoBuildDir, relativePath);
     }
 
-    return Path.of(mavenSession.getExecutionRootDirectory(), DEFAULT_BUILD_DIR_NAME, relativePath).toFile();
+    return FileSystems
+        .getDefault()
+        .getPath(mavenSession.getExecutionRootDirectory(), DEFAULT_BUILD_DIR_NAME, relativePath).toFile();
   }
 
   private MavenProject getFirstProjectWithThisPluginDefined(

--- a/src/main/java/org/sonatype/central/publisher/plugin/utils/ProjectUtilsImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/utils/ProjectUtilsImpl.java
@@ -5,6 +5,7 @@
 package org.sonatype.central.publisher.plugin.utils;
 
 import java.io.File;
+import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -103,7 +104,7 @@ public class ProjectUtilsImpl
   public Path getProjectGroupPath(final MavenProject project) {
     String[] groupPathParts = project.getGroupId().split("\\.");
 
-    Path path = Path.of("");
+    Path path = FileSystems.getDefault().getPath("");
 
     for (String groupPathPart : groupPathParts) {
       path = path.resolve(groupPathPart);

--- a/src/main/java/org/sonatype/central/publisher/plugin/watcher/DeploymentPublishedWatcherImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/watcher/DeploymentPublishedWatcherImpl.java
@@ -7,6 +7,7 @@ package org.sonatype.central.publisher.plugin.watcher;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -24,6 +25,7 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 
 import static java.lang.String.format;
+import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Component(role = DeploymentPublishedWatcher.class)
@@ -57,7 +59,7 @@ public class DeploymentPublishedWatcherImpl
         "Waiting until Deployment %s is %s", deploymentId, waitForDeploymentStateRequest.waitTypeName()));
 
     try {
-      while (Duration.between(start, Instant.now()).toSeconds() <
+      while (Duration.between(start, Instant.now()).get(SECONDS) <
           waitForDeploymentStateRequest.getWaitMaxTimeInSeconds()) {
 
         // convert to milliseconds


### PR DESCRIPTION
- update source code with https://repo1.maven.org/maven2/org/sonatype/central/central-publishing-maven-plugin/0.4.0/central-publishing-maven-plugin-0.4.0-sources.jar
  - remove dependency to central-publishing-client
  - add own code for PublisherClient implementation instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces a publishing client to compose bundles, upload deployments, check status, and verify publication.
  - Supports Basic and User Token authentication with configurable Central base URL.
  - Adds a bundle builder to zip project files from a source directory.

- Chores
  - Bumps version to 0.4.0.
  - Updates dependencies and test libraries; removes an obsolete dependency.
  - Cleans up plugin configuration for Javadoc.

- Refactor
  - Simplifies client initialization and path handling in utilities and plugins for reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->