### PR TITLE
Update to version 0.6.0 from central-publishing-maven-plugin-0.6.0-sources.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.sonatype.central</groupId>
   <artifactId>central-publishing-maven-plugin</artifactId>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <packaging>maven-plugin</packaging>
 
   <name>Central Publishing Maven Plugin</name>


### PR DESCRIPTION
- update source code with https://repo1.maven.org/maven2/org/sonatype/central/central-publishing-maven-plugin/0.6.0/central-publishing-maven-plugin-0.6.0-sources.jar
  - fix to support Maven settings encryption for server related authentication credentials

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adds support for decrypting credentials from Maven settings during publish operations. Users with encrypted server credentials can authenticate without manual steps, improving security and compatibility with standard Maven setups.

* **Chores**
  * Upgraded the central publishing Maven plugin to version 0.6.0 to align with the latest tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->