### PR TITLE
Fix vulnerability due to commons-lang3 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
+      <version>3.18.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
- bump commons-lang3 version 3.12.0 -> 3.18.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Apache Commons Lang library to version 3.18.0.
  * General dependency maintenance; no changes to features or UI expected.
  * Potential minor performance and reliability improvements under the hood.
  * Ensures compatibility with newer runtime environments and tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->