### PR TITLE
Fix typo of plugin configuration parameter 'waitUtil' -> 'waitUntil'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
               <publishingServerId>publisher</publishingServerId>
               <deploymentName>Central Publishing Maven Plugin - ${project.version}</deploymentName>
               <autoPublish>true</autoPublish>
-              <waitUtil>published</waitUtil>
+              <waitUntil>published</waitUntil>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
- pom.xml:
  - bump version to 0.8.1-SNAPSHOT
  - add missing <relativePath> in <parent> to make Eclipse POM editor/parser happy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publishing plugin configuration to use the correct wait parameter for improved reliability during releases.
  * Aligns build pipeline with latest plugin behavior to maintain compatibility and reduce deployment stalls.
  * Internal deployment-only adjustment; no impact on application features, performance, or UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->