### PR TITLE
Fix JavaDoc warning on ArtifactDeferrerImpl.java

### DIFF
--- a/src/main/java/org/sonatype/central/publisher/plugin/deffer/ArtifactDeferrerImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/deffer/ArtifactDeferrerImpl.java
@@ -106,7 +106,7 @@ public class ArtifactDeferrerImpl
    * @param request - {@link DeferArtifactRequest}
    * @throws ArtifactInstallationException - if the artifact installation fails
    * @throws MojoExecutionException        - if the staging directory is null or the artifact repo cannot be created
-   * @see ArtifactDeferrer#install(File, Artifact, ArtifactRepository, File, ArtifactRepository)
+   * @see #install(File, Artifact, ArtifactRepository, File, ArtifactRepository)
    */
   @Override
   @SuppressWarnings("deprecation")


### PR DESCRIPTION
- ArtifactDeferrerImpl.java:
  - fix JavaDoc on method install(final DeferArtifactRequest request)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected an API documentation reference to the appropriate install method overload, improving accuracy for developers.
  * Updated inline Javadoc to fix a misleading cross-reference, reducing confusion when navigating developer docs.
  * No functional changes: behavior, configuration, and public APIs remain unchanged.
  * This is a documentation-only update and does not affect runtime behavior or compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->