### PR TITLE
Enhance for Spotless code formatting and Maven site building

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -26,6 +26,8 @@ jobs:
     uses: mavenplugins/reusable-gh-actions/.github/workflows/__maven_clean_deploy.yml@master
     with:
       runner: ubuntu-latest
+      javaHomeVersion: '17'
+      mavenVersion: '3.9.6'
       # Allow to deploy release version to test staging validation on OSSRH
       # Note: A release version will NOT be relased to Maven Central by this workflow!
       # Releasing to Maven Central will be performed via Unleash workflow only

--- a/.github/workflows/unleash.yml
+++ b/.github/workflows/unleash.yml
@@ -33,6 +33,8 @@ jobs:
     uses: mavenplugins/reusable-gh-actions/.github/workflows/__maven_unleash.yml@master
     with:
       runner: ubuntu-latest
+      javaHomeVersion: '17'
+      mavenVersion: '3.9.6'
       releaseVersion: ${{ inputs.releaseVersion }}
       nextSnapshotVersion: ${{ inputs.nextSnapshotVersion }}
       releaseToMavenCentral: ${{ inputs.releaseToMavenCentral }}
@@ -46,6 +48,8 @@ jobs:
     uses: mavenplugins/reusable-gh-actions/.github/workflows/__maven_clean_deploy.yml@master
     with:
       runner: ubuntu-latest
+      javaHomeVersion: '17'
+      mavenVersion: '3.9.6'
       deploy_snapshots_only: true
 
     secrets: inherit

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,2 @@
+--add-opens java.base/java.lang=ALL-UNNAMED
+--add-opens java.base/java.util=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,9 @@
     Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
     "Sonatype" is a trademark of Sonatype, Inc.
 
---><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.github.mavenplugins</groupId>
@@ -30,7 +32,7 @@
     <url>https://github.com/mavenplugins/central-publishing-maven-plugin</url>
     <connection>scm:git:https://github.com/mavenplugins/central-publishing-maven-plugin.git</connection>
     <developerConnection>scm:git:https://github.com/mavenplugins/central-publishing-maven-plugin.git</developerConnection>
-<tag>HEAD</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <url>https://central.sonatype.org</url>
@@ -39,13 +41,15 @@
     <groupId>org.sonatype.buildsupport</groupId>
     <artifactId>buildsupport</artifactId>
     <version>32</version>
-    <relativePath/>
+    <relativePath />
   </parent>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.showDeprecation>false</maven.compiler.showDeprecation>
+    <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
   </properties>
 
   <dependencies>
@@ -294,6 +298,37 @@
             <daemonThreadJoinTimeout>5000</daemonThreadJoinTimeout>
           </configuration>
         </plugin>
+        <plugin>
+          <!-- see developer-documentation/development/formatting.md -->
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>2.46.1</version>
+          <configuration>
+            <!-- Note: On CI ratchetFrom requires 'git fetch origin master' to be performed at least once. -->
+            <!-- <ratchetFrom>origin/master</ratchetFrom> -->
+            <formats>
+              <format>
+                <includes>
+                  <include>*.java</include>
+                </includes>
+                <excludes>
+                  <exclude>target/generated-sources/**/*.java</exclude>
+                </excludes>
+                <trimTrailingWhitespace />
+                <endWithNewline />
+              </format>
+            </formats>
+            <java>
+              <removeUnusedImports />
+              <importOrder>
+                <file>${basedir}/sonatype/codestyle/sonatype-eclipse-imports.importorder</file>
+              </importOrder>
+              <eclipse>
+                <file>${basedir}/sonatype/codestyle/sonatype-eclipse.xml</file>
+              </eclipse>
+            </java>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -328,6 +363,22 @@
             <goals>
               <goal>descriptor</goal>
               <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!-- The default behavior is to run the check goal. -->
+        <!-- Perform 'mvn spotless:apply' manually on demand. -->
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Runs in compile phase to fail early in case of formatting issues. -->
+            <id>spotless-check</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>check</goal>
             </goals>
           </execution>
         </executions>
@@ -516,6 +567,9 @@
         <public-snapshot.serverId>${organization.snapshotNexusRepoId}</public-snapshot.serverId>
         <public-snapshot.url>${organization.snapshotNexusURL}</public-snapshot.url>
 
+        <!-- Note: Override javadoc.doclint if required. This must be set for JAVADOC >= 8 only! -->
+        <javadoc.doclint />
+
         <!-- Plugin configuration properties -->
         <skip.attach-sources>false</skip.attach-sources>
         <!-- Note: Overwrite <phase.attach-javadocs> with none or empty value, if attached-javadocs must be skipped -->
@@ -528,7 +582,7 @@
         <toolchain.executionPhase>${toolchain.executionDisablePhase}</toolchain.executionPhase>
         <!-- Note: toolchain.jdkVersion is empty by default. It is supposed to be either set by profile 'toolchain'
                    below, by -D option via MAVEN_OPTS, on mvn commandline or by settings.xml -->
-        <toolchain.jdkVersion/>
+        <toolchain.jdkVersion />
         <!-- Sonatype staging -->
         <!-- staging.autoPublish: should be set to false for testing on release version deployments. -->
         <staging.autoPublish>true</staging.autoPublish>
@@ -563,7 +617,12 @@
         <staging.waitUntil>${staging.waitUntilPublishedState}</staging.waitUntil>
 
         <!-- Apache Maven Plugin versions -->
+        <version.maven-compiler-plugin>3.12.1</version.maven-compiler-plugin>
+        <version.maven-javadoc-plugin>3.6.0</version.maven-javadoc-plugin>
         <version.maven-toolchains-plugin>3.1.0</version.maven-toolchains-plugin>
+        <version.maven-plugin-report-plugin>4.0.0-beta-1</version.maven-plugin-report-plugin>
+        <version.maven-project-info-reports-plugin>3.9.0</version.maven-project-info-reports-plugin>
+        <version.maven-site-plugin>3.21.0</version.maven-site-plugin>
 
         <!-- Sonatype Maven Central Publishing Plugin GAVs -->
         <groupId.central-publishing-maven-plugin.released>io.github.mavenplugins</groupId.central-publishing-maven-plugin.released>
@@ -598,6 +657,42 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-toolchains-plugin</artifactId>
               <version>${version.maven-toolchains-plugin}</version>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>${version.maven-compiler-plugin}</version>
+              <configuration>
+                <source>${maven.compiler.source}</source>
+                <target>${maven.compiler.target}</target>
+                <debug>true</debug>
+                <!-- <fork>true</fork> -->
+                <!-- <compilerArgument>${maven.compiler.compilerArgument}</compilerArgument> -->
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>${version.maven-javadoc-plugin}</version>
+              <configuration>
+                <!-- Prevent javadoc lint warnings from failing builds -->
+                <doclint>${javadoc.doclint}</doclint>
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-plugin-report-plugin</artifactId>
+              <version>${version.maven-plugin-report-plugin}</version>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-project-info-reports-plugin</artifactId>
+              <version>${version.maven-project-info-reports-plugin}</version>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-site-plugin</artifactId>
+              <version>${version.maven-site-plugin}</version>
             </plugin>
             <plugin>
               <groupId>${groupId.unleash-maven-plugin}</groupId>
@@ -680,11 +775,31 @@
           </plugin>
         </plugins>
       </build>
+      <reporting>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-plugin-report-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </reporting>
     </profile>
 
     <!-- ====================================================== -->
     <!-- mavenplugins deploy and release profiles for GitHub CI -->
     <!-- ====================================================== -->
+    <!--
+    Turn off strict javadoc checks in Java-8+.
+    -->
+    <profile>
+      <id>mavenplugins-javadoc-java8</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.doclint>none</javadoc.doclint>
+      </properties>
+    </profile>
     <profile>
       <id>mavenplugins-toolchain</id>
       <!-- Toolchain profile: Activated if SysEnv variable MAVEN_TOOLCHAIN_VERSION is defined. -->

--- a/sonatype/codestyle/ReadMe.txt
+++ b/sonatype/codestyle/ReadMe.txt
@@ -1,0 +1,9 @@
+Download sources:
+-----------------
+- sonatype-eclipse.xml:
+  - https://raw.githubusercontent.com/sonatype/nexus-public/refs/heads/main/sonatype-config/sonatype-eclipse.xml
+
+- sonatype-eclipse-imports.importorder:
+  - https://raw.githubusercontent.com/sonatype/codestyle/refs/heads/main/sonatype-eclipse-imports.importorder
+
+- EOF -

--- a/sonatype/codestyle/sonatype-eclipse-imports.importorder
+++ b/sonatype/codestyle/sonatype-eclipse-imports.importorder
@@ -1,0 +1,8 @@
+#Organize Import Order
+#Tue Jun 11 12:45:09 EDT 2013
+5=\#
+4=
+3=org.sonatype
+2=com.sonatype
+1=javax
+0=java

--- a/sonatype/codestyle/sonatype-eclipse.xml
+++ b/sonatype/codestyle/sonatype-eclipse.xml
@@ -1,0 +1,455 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="23">
+  <profile kind="CodeFormatterProfile" name="Sonatype" version="23">
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters"
+             value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration"
+             value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+    <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_before_code_block" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_switch_case_expressions"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations"
+             value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+    <setting
+        id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference"
+        value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_record_components" value="48"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_multiplicative_operator" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments"
+             value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_logical_operator" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_annotation_declaration_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_record_declaration"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_multiplicative_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments"
+             value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_abstract_method" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_enum_constant_declaration_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference"
+             value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiplicative_operator" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_switch_case_expressions" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_shift_operator" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header"
+             value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_code_block" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_bitwise_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="48"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_switch_case_arrow_operator" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_enum_constant" value="49"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.text_block_indentation" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_if_then_body_block_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_permitted_types" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression_chain" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_annotations" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_assertion_message_operator" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_bitwise_operator" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="next_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="80"/>
+    <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="33"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_not_operator" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package" value="49"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header"
+             value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_case" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_permitted_types_in_type_declaration" value="33"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_record_header" value="true"/>
+    <setting
+        id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference"
+        value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_bitwise_operator" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.javadoc_do_not_separate_block_tags" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.indent_tag_description" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_record_constructor" value="next_line_on_wrap"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_string_concatenation" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_shift_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration"
+             value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_shift_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_simple_do_while_body_on_same_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration"
+             value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_record_components" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_additive_operator" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_simple_getter_setter_on_one_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case_after_arrow" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_string_concatenation" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_record_declaration"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_relational_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_logical_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_record_declaration" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws"
+             value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_default" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="17"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_method_body" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_case" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_switch_body_block_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="next_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_switch_case_with_arrow" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
+    <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_loop_body_block_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="next_line_on_wrap"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_type_declaration_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_additive_operator" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_record_constructor" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_relational_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_record_declaration_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="next_line_on_wrap"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_relational_operator" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.align_arrows_in_switch_on_columns" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_additive_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_string_concatenation" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.align_selector_in_method_invocation_on_expression_first_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_record_declaration" value="next_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_switch_case_with_arrow_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_switch_case_with_colon" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_after_code_block" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="33"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="48"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type" value="49"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable" value="49"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="next_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_default" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_between_different_tags" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_additive_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field" value="49"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.join_line_comments" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_shift_operator" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_code_block_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_record_components" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="2"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_bitwise_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_record_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="17"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_switch_case_with_arrow" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_lambda_body_block_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method" value="49"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_record_constructor_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_record_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_assertion_message" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_logical_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_record_declaration" value="33"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_relational_operator" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="48"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_logical_operator" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_statement_group_in_switch" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_permitted_types" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_enum_declaration_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="next_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_multiplicative_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_code_block" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_string_concatenation" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+  </profile>
+</profiles>

--- a/src/main/java/org/sonatype/central/publisher/client/PublisherClientImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/client/PublisherClientImpl.java
@@ -60,7 +60,9 @@ class PublisherClientImpl
 
   @Override
   public PublisherBundle compose(final Path sourceDir, final Path destDir, final String bundleFileName) {
-    return new BundleBuilder(sourceDir).destPath(destDir).bundleName(bundleFileName).addAllSourceFiles()
+    return new BundleBuilder(sourceDir).destPath(destDir)
+        .bundleName(bundleFileName)
+        .addAllSourceFiles()
         .build();
   }
 

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/ComponentPublishedEndpoint.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/ComponentPublishedEndpoint.java
@@ -34,7 +34,9 @@ public class ComponentPublishedEndpoint
   {
     try {
       String response = sendRequest(authProvider, baseUrl + PUBLISHED_ENDPOINT_URL, params, null, RequestType.GET);
-      Map<String, Boolean> result = objectMapper.readValue(response, new TypeReference<HashMap<String, Boolean>>() { });
+      Map<String, Boolean> result = objectMapper.readValue(response, new TypeReference<HashMap<String, Boolean>>()
+      {
+      });
       return result.get("published");
     }
     catch (HttpResponseException e) {

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/RequestType.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/RequestType.java
@@ -7,5 +7,6 @@ package org.sonatype.central.publisher.client.httpclient;
 
 public enum RequestType
 {
-  POST, GET
+  POST,
+  GET
 }

--- a/src/main/java/org/sonatype/central/publisher/plugin/AbstractPublisherMojo.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/AbstractPublisherMojo.java
@@ -89,9 +89,7 @@ public abstract class AbstractPublisherMojo
   }
 
   @Override
-  public void execute()
-      throws MojoExecutionException
-  {
+  public void execute() throws MojoExecutionException {
     validateParameters();
     doExecute();
   }

--- a/src/main/java/org/sonatype/central/publisher/plugin/Constants.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/Constants.java
@@ -76,7 +76,8 @@ public class Constants
 
   public static final String CENTRAL_BASE_URL_DEFAULT_VALUE = "https://central.sonatype.com";
 
-  public static final String CENTRAL_SNAPSHOTS_URL_DEFAULT_VALUE = CENTRAL_BASE_URL_DEFAULT_VALUE + "/repository/maven-snapshots/";
+  public static final String CENTRAL_SNAPSHOTS_URL_DEFAULT_VALUE =
+      CENTRAL_BASE_URL_DEFAULT_VALUE + "/repository/maven-snapshots/";
 
   public static final String IGNORE_PUBLISHED_COMPONENTS_NAME = "ignorePublishedComponents";
 

--- a/src/main/java/org/sonatype/central/publisher/plugin/DeployLifecycleParticipant.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/DeployLifecycleParticipant.java
@@ -24,15 +24,14 @@ import static org.sonatype.central.publisher.plugin.Constants.CENTRAL_PUBLISHING
 import static org.sonatype.central.publisher.plugin.Constants.DEPLOY_PHASE;
 import static org.sonatype.central.publisher.plugin.Constants.MAVEN_DEPLOY_PLUGIN_ARTIFACT_ID;
 import static org.sonatype.central.publisher.plugin.Constants.MAVEN_DEPLOY_PLUGIN_GROUP_ID;
-import static org.sonatype.central.publisher.plugin.Constants.NEXUS_STAGING_PLUGIN_GROUP_ID;
 import static org.sonatype.central.publisher.plugin.Constants.NEXUS_STAGING_PLUGIN_ARTIFACT_ID;
+import static org.sonatype.central.publisher.plugin.Constants.NEXUS_STAGING_PLUGIN_GROUP_ID;
 import static org.sonatype.central.publisher.plugin.Constants.PUBLISH_GOAL;
 import static org.sonatype.central.publisher.plugin.Constants.PUBLISH_GOAL_ID;
 
 @Component(
     role = AbstractMavenLifecycleParticipant.class,
-    hint = "org.sonatype.central.publisher.plugin.DeployLifecycleParticipant"
-)
+    hint = "org.sonatype.central.publisher.plugin.DeployLifecycleParticipant")
 public class DeployLifecycleParticipant
     extends AbstractMavenLifecycleParticipant
     implements LogEnabled

--- a/src/main/java/org/sonatype/central/publisher/plugin/PublishMojo.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/PublishMojo.java
@@ -88,8 +88,7 @@ public class PublishMojo
    */
   @Parameter(
       property = WAIT_UNTIL_NAME,
-      defaultValue = WAIT_UNTIL_DEFAULT_VALUE
-  )
+      defaultValue = WAIT_UNTIL_DEFAULT_VALUE)
   private String waitUntil;
 
   /**
@@ -98,8 +97,7 @@ public class PublishMojo
    */
   @Parameter(
       property = WAIT_MAX_TIME_NAME,
-      defaultValue = WAIT_MAX_TIME_DEFAULT_VALUE
-  )
+      defaultValue = WAIT_MAX_TIME_DEFAULT_VALUE)
   private int waitMaxTime;
 
   /**
@@ -108,8 +106,7 @@ public class PublishMojo
    */
   @Parameter(
       property = WAIT_POLLING_INTERVAL_NAME,
-      defaultValue = WAIT_POLLING_INTERVAL_DEFAULT_VALUE
-  )
+      defaultValue = WAIT_POLLING_INTERVAL_DEFAULT_VALUE)
   private int waitPollingInterval;
 
   /**
@@ -118,8 +115,7 @@ public class PublishMojo
   @Deprecated
   @Parameter(
       property = PUBLISH_COMPLETION_POLL_INTERVAL_NAME,
-      defaultValue = PUBLISH_COMPLETION_POLL_INTERVAL_DEFAULT_VALUE
-  )
+      defaultValue = PUBLISH_COMPLETION_POLL_INTERVAL_DEFAULT_VALUE)
   private int publishCompletionPollInterval;
 
   /**
@@ -216,8 +212,7 @@ public class PublishMojo
       getLog().warn(format(
           "%s is deprecated, using it will set %s (converted to seconds).",
           PUBLISH_COMPLETION_POLL_INTERVAL_NAME,
-          WAIT_MAX_TIME_NAME
-      ));
+          WAIT_MAX_TIME_NAME));
 
       // only update waitPollingInterval if it was still set to the default
       if (waitPollingInterval == waitPollingIntervalDefault) {
@@ -230,8 +225,7 @@ public class PublishMojo
       getLog().warn(format(
           "%s was set to be less then %2$s seconds, will use the default of %2$s seconds.",
           WAIT_POLLING_INTERVAL_NAME,
-          WAIT_POLLING_INTERVAL_DEFAULT_VALUE
-      ));
+          WAIT_POLLING_INTERVAL_DEFAULT_VALUE));
 
       waitPollingInterval = waitPollingIntervalDefault;
     }
@@ -242,8 +236,7 @@ public class PublishMojo
       getLog().warn(format(
           "%s was set to be less then %2$s seconds, will use the default of %2$s seconds.",
           WAIT_MAX_TIME_NAME,
-          WAIT_MAX_TIME_DEFAULT_VALUE
-      ));
+          WAIT_MAX_TIME_DEFAULT_VALUE));
 
       waitMaxTime = waitMaxTimeDefault;
     }
@@ -251,8 +244,7 @@ public class PublishMojo
     if (!ChecksumRequest.isValidValue(checksums)) {
       throw new MojoExecutionException(format("%s must be one of the following values %s.",
           CHECKSUMS_NAME,
-          ChecksumRequest.toNames())
-      );
+          ChecksumRequest.toNames()));
     }
 
     checksumRequest = ChecksumRequest.valueOf(checksums.toUpperCase());
@@ -260,8 +252,7 @@ public class PublishMojo
     if (!WaitUntilRequest.isValidValue(waitUntil)) {
       throw new MojoExecutionException(format("%s must be one of the following values %s.",
           WAIT_UNTIL_NAME,
-          WaitUntilRequest.toNames())
-      );
+          WaitUntilRequest.toNames()));
     }
 
     waitUntilRequest = WaitUntilRequest.valueOf(waitUntil.toUpperCase());
@@ -273,8 +264,7 @@ public class PublishMojo
           "waitForPublishCompletion is deprecated, using it will set %s to true and %s to %s.",
           AUTO_PUBLISH_NAME,
           WAIT_UNTIL_NAME,
-          WaitUntilRequest.PUBLISHED.name().toLowerCase()
-      ));
+          WaitUntilRequest.PUBLISHED.name().toLowerCase()));
 
       publishingType = PublishingType.AUTOMATIC;
       waitUntilRequest = WaitUntilRequest.PUBLISHED;
@@ -288,8 +278,7 @@ public class PublishMojo
           waitUntilRequest.name().toLowerCase(),
           AUTO_PUBLISH_NAME,
           AUTO_PUBLISH_DEFAULT_VALUE,
-          WaitUntilRequest.VALIDATED.name().toLowerCase()
-      ));
+          WaitUntilRequest.VALIDATED.name().toLowerCase()));
 
       waitUntilRequest = WaitUntilRequest.VALIDATED;
     }
@@ -343,9 +332,7 @@ public class PublishMojo
     }
   }
 
-  private void postProcessSnapshot(final File deferredDirectory)
-      throws MojoExecutionException
-  {
+  private void postProcessSnapshot(final File deferredDirectory) throws MojoExecutionException {
     try {
       if (Files.exists(new File(deferredDirectory, INDEX_FILE_NAME).toPath())) {
 
@@ -366,8 +353,9 @@ public class PublishMojo
     }
   }
 
-  protected void processSnapshot(final List<ArtifactWithFile> artifactWithFiles, final File deferredDirectory)
-      throws MojoExecutionException
+  protected void processSnapshot(
+      final List<ArtifactWithFile> artifactWithFiles,
+      final File deferredDirectory) throws MojoExecutionException
   {
     List<ArtifactWithFile> filteredArtifactWithFiles = artifactWithFiles.stream()
         .filter(artifactWithFile -> !excludeArtifacts.contains(artifactWithFile.getArtifact().getArtifactId()))
@@ -380,17 +368,16 @@ public class PublishMojo
               filteredArtifactWithFiles,
               deferredDirectory,
               centralSnapshotsUrl,
-              publishingServerId
-          )
-      );
+              publishingServerId));
     }
     catch (ArtifactInstallationException e) {
       throw new MojoExecutionException(e.getMessage(), e);
     }
   }
 
-  protected void processRelease(final List<ArtifactWithFile> artifactWithFiles, final File stagingDirectory)
-      throws MojoExecutionException
+  protected void processRelease(
+      final List<ArtifactWithFile> artifactWithFiles,
+      final File stagingDirectory) throws MojoExecutionException
   {
     List<ArtifactWithFile> filteredArtifactWithFiles = artifactWithFiles.stream()
         .filter(artifactWithFile -> {
@@ -404,7 +391,8 @@ public class PublishMojo
           }
 
           return true;
-        }).collect(toList());
+        })
+        .collect(toList());
 
     try {
       artifactStager.stageArtifact(new StageArtifactRequest(filteredArtifactWithFiles, stagingDirectory));
@@ -431,8 +419,7 @@ public class PublishMojo
             stagingDirectory,
             outputDirectory,
             outputFilename,
-            checksumRequest
-        ));
+            checksumRequest));
 
     if (isSkipPublishing()) {
       getLog().info("Skipping Central Release Publishing at user's request.");
@@ -452,8 +439,7 @@ public class PublishMojo
         deploymentId,
         waitUntilRequest,
         waitMaxTime,
-        waitPollingInterval
-    );
+        waitPollingInterval);
 
     deploymentPublishedWatcher.waitForDeploymentState(waitForDeploymentStateRequest);
   }
@@ -468,7 +454,7 @@ public class PublishMojo
    * because the first execution of this plugin cleans the working directory.
    *
    * @param forcedWorkDirectory an override File that points to a valid directory
-   * @param relativePath        a path relative to the working directory root for the folder
+   * @param relativePath a path relative to the working directory root for the folder
    * @return a File that points to a valid empty directory for the plugin to use as temporary working storage
    */
   protected synchronized File getWorkDirectory(final File forcedWorkDirectory, final String relativePath) {
@@ -492,8 +478,7 @@ public class PublishMojo
         getMojoExecution(),
         getPluginGroupId(),
         getPluginArtifactId(),
-        isFailOnBuildFailure()
-    );
+        isFailOnBuildFailure());
   }
 
   private void ensureCleanDirectory(File workingDirectory) {
@@ -555,8 +540,7 @@ public class PublishMojo
         "Deployment %s has been %s. To finish publishing visit %s/publishing/deployments",
         deploymentId,
         waitUntilRequest.name().toLowerCase(),
-        centralBaseURL
-    ));
+        centralBaseURL));
   }
 
   private boolean hasFiles(final File directory) {

--- a/src/main/java/org/sonatype/central/publisher/plugin/config/PlexusContextConfigImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/config/PlexusContextConfigImpl.java
@@ -16,7 +16,8 @@ import org.codehaus.plexus.context.ContextException;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
 
 @Component(role = PlexusContextConfig.class)
-public class PlexusContextConfigImpl implements PlexusContextConfig, Contextualizable
+public class PlexusContextConfigImpl
+    implements PlexusContextConfig, Contextualizable
 {
   @Override
   public void contextualize(final Context context) throws ContextException {

--- a/src/main/java/org/sonatype/central/publisher/plugin/deffer/ArtifactDeferrer.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/deffer/ArtifactDeferrer.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 
 import org.sonatype.central.publisher.plugin.model.DeferArtifactRequest;
 
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.deployer.ArtifactDeploymentException;
 import org.apache.maven.artifact.installer.ArtifactInstallationException;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -26,21 +25,22 @@ public interface ArtifactDeferrer
    *
    * @param artifactWithFiles artifact with files to install
    * @throws ArtifactInstallationException if installation fails
-   * @throws MojoExecutionException        if execution fails
+   * @throws MojoExecutionException if execution fails
    */
-  void install(DeferArtifactRequest artifactWithFiles)
-      throws ArtifactInstallationException, MojoExecutionException;
+  void install(DeferArtifactRequest artifactWithFiles) throws ArtifactInstallationException, MojoExecutionException;
 
   /**
    * Deploy artifact.
    *
-   * @param mavenSession     - {@link MavenSession}
-   * @param sourceDirectory  - {@link File}
+   * @param mavenSession - {@link MavenSession}
+   * @param sourceDirectory - {@link File}
    * @param remoteRepository - {@link ArtifactRepository}
    * @throws ArtifactDeploymentException if deployment fails
-   * @throws IOException                 if reading of index fails
+   * @throws IOException if reading of index fails
    */
   @SuppressWarnings("deprecation")
-  void deployUp(MavenSession mavenSession, File sourceDirectory, ArtifactRepository remoteRepository)
-      throws ArtifactDeploymentException, IOException;
+  void deployUp(
+      MavenSession mavenSession,
+      File sourceDirectory,
+      ArtifactRepository remoteRepository) throws ArtifactDeploymentException, IOException;
 }

--- a/src/main/java/org/sonatype/central/publisher/plugin/exceptions/ArtifactUploadFailedException.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/exceptions/ArtifactUploadFailedException.java
@@ -5,7 +5,8 @@
 
 package org.sonatype.central.publisher.plugin.exceptions;
 
-public class ArtifactUploadFailedException extends RuntimeException
+public class ArtifactUploadFailedException
+    extends RuntimeException
 {
   public ArtifactUploadFailedException(String deploymentName, Exception e) {
     super("Artifact for deployment " + deploymentName + " failed while uploading", e);

--- a/src/main/java/org/sonatype/central/publisher/plugin/exceptions/DeploymentPublishFailedException.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/exceptions/DeploymentPublishFailedException.java
@@ -5,7 +5,8 @@
 
 package org.sonatype.central.publisher.plugin.exceptions;
 
-public class DeploymentPublishFailedException extends RuntimeException
+public class DeploymentPublishFailedException
+    extends RuntimeException
 {
 
   public DeploymentPublishFailedException(String deploymentId, String deploymentName) {

--- a/src/main/java/org/sonatype/central/publisher/plugin/exceptions/DeploymentPublishTimedOutException.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/exceptions/DeploymentPublishTimedOutException.java
@@ -5,7 +5,8 @@
 
 package org.sonatype.central.publisher.plugin.exceptions;
 
-public class DeploymentPublishTimedOutException extends RuntimeException
+public class DeploymentPublishTimedOutException
+    extends RuntimeException
 {
   public DeploymentPublishTimedOutException(String deploymentId) {
     super("Polling for " + deploymentId + " timed out before the deployment completed.");

--- a/src/main/java/org/sonatype/central/publisher/plugin/model/BundleArtifactRequest.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/model/BundleArtifactRequest.java
@@ -25,8 +25,7 @@ public class BundleArtifactRequest
       final File stagingDirectory,
       final File outputDirectory,
       final String outputFilename,
-      final ChecksumRequest checksumRequest
-  )
+      final ChecksumRequest checksumRequest)
   {
     this.project = project;
     this.stagingDirectory = stagingDirectory;

--- a/src/main/java/org/sonatype/central/publisher/plugin/model/DeferArtifactRequest.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/model/DeferArtifactRequest.java
@@ -24,11 +24,11 @@ public class DeferArtifactRequest
   /**
    * Constructor
    *
-   * @param mavenSession        - {@link MavenSession}
-   * @param artifactWithFiles   - {@link List} of {@link ArtifactWithFile}
-   * @param deferredDirectory   - {@link File} directory to defer the artifacts
+   * @param mavenSession - {@link MavenSession}
+   * @param artifactWithFiles - {@link List} of {@link ArtifactWithFile}
+   * @param deferredDirectory - {@link File} directory to defer the artifacts
    * @param centralSnapshotsUrl - {@link String} URL of the central snapshots
-   * @param serverId  - {@link String} server id
+   * @param serverId - {@link String} server id
    */
   public DeferArtifactRequest(
       final MavenSession mavenSession,

--- a/src/main/java/org/sonatype/central/publisher/plugin/model/UploadArtifactRequest.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/model/UploadArtifactRequest.java
@@ -19,8 +19,7 @@ public class UploadArtifactRequest
   public UploadArtifactRequest(
       final String deploymentName,
       final Path bundleFile,
-      final PublishingType publishingType
-  )
+      final PublishingType publishingType)
   {
     this.deploymentName = deploymentName;
     this.bundleFile = bundleFile;

--- a/src/main/java/org/sonatype/central/publisher/plugin/model/WaitForDeploymentStateRequest.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/model/WaitForDeploymentStateRequest.java
@@ -24,8 +24,7 @@ public class WaitForDeploymentStateRequest
       final String deploymentId,
       final WaitUntilRequest waitUntilRequest,
       final int waitMaxTimeInSeconds,
-      final int waitPollingIntervalInSeconds
-  )
+      final int waitPollingIntervalInSeconds)
   {
     this.centralBaseUrl = centralBaseUrl;
     this.deploymentId = deploymentId;

--- a/src/main/java/org/sonatype/central/publisher/plugin/stager/ArtifactStager.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/stager/ArtifactStager.java
@@ -11,6 +11,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 
 public interface ArtifactStager
 {
-  void stageArtifact(final StageArtifactRequest stageArtifactRequest)
-      throws MojoExecutionException, ArtifactInstallationException;
+  void stageArtifact(
+      final StageArtifactRequest stageArtifactRequest) throws MojoExecutionException, ArtifactInstallationException;
 }

--- a/src/main/java/org/sonatype/central/publisher/plugin/stager/ArtifactStagerImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/stager/ArtifactStagerImpl.java
@@ -41,8 +41,8 @@ public class ArtifactStagerImpl
   private ArtifactRepositoryLayout artifactRepositoryLayout;
 
   @Override
-  public void stageArtifact(final StageArtifactRequest stageArtifactRequest)
-      throws MojoExecutionException, ArtifactInstallationException
+  public void stageArtifact(
+      final StageArtifactRequest stageArtifactRequest) throws MojoExecutionException, ArtifactInstallationException
   {
     if (!stageArtifactRequest.getArtifactWithFiles().isEmpty()) {
       getLogger().info("Staging " + stageArtifactRequest.getArtifactWithFiles().size() + " files");
@@ -60,8 +60,10 @@ public class ArtifactStagerImpl
     }
   }
 
-  protected void install(final File source, final Artifact artifact, final ArtifactRepository stagingRepository)
-      throws ArtifactInstallationException
+  protected void install(
+      final File source,
+      final Artifact artifact,
+      final ArtifactRepository stagingRepository) throws ArtifactInstallationException
   {
     synchronized (parallelLock) {
       getLogger().info("Staging " + source.getAbsolutePath());

--- a/src/main/java/org/sonatype/central/publisher/plugin/uploader/ArtifactUploaderImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/uploader/ArtifactUploaderImpl.java
@@ -25,7 +25,8 @@ public class ArtifactUploaderImpl
   private PublisherClient publisherClient;
 
   @SuppressWarnings("unused") // used via reflection by Plexus
-  public ArtifactUploaderImpl() { }
+  public ArtifactUploaderImpl() {
+  }
 
   ArtifactUploaderImpl(final PublisherClient publisherClient) {
     this.publisherClient = publisherClient != null ? publisherClient : PublisherClientFactory.createPublisherClient();
@@ -41,15 +42,13 @@ public class ArtifactUploaderImpl
       String deploymentId = publisherClient.upload(
           uploadArtifactRequest.getDeploymentName(),
           uploadArtifactRequest.getBundleFile(),
-          uploadArtifactRequest.getPublishingType()
-      );
+          uploadArtifactRequest.getPublishingType());
 
       if (getLogger() != null) {
         getLogger().info(
             format("Uploaded bundle successfully, deployment name: %s, deploymentId: %s. Deployment will %s",
                 uploadArtifactRequest.getDeploymentName(), deploymentId,
-                toPublishingTypeMessage(uploadArtifactRequest))
-        );
+                toPublishingTypeMessage(uploadArtifactRequest)));
       }
 
       return deploymentId;

--- a/src/main/java/org/sonatype/central/publisher/plugin/utils/AuthData.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/utils/AuthData.java
@@ -8,6 +8,7 @@ package org.sonatype.central.publisher.plugin.utils;
 public class AuthData
 {
   private final String username;
+
   private final String password;
 
   public AuthData(final String username, final String password) {

--- a/src/main/java/org/sonatype/central/publisher/plugin/utils/HashUtils.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/utils/HashUtils.java
@@ -13,7 +13,7 @@ public interface HashUtils
   /**
    * Get the hash for a given file.
    *
-   * @param file      - {@link File}
+   * @param file - {@link File}
    * @param algorithm - {@link HashAlgorithm}
    * @return String or null if the file didn't exist or issues occurred reading it.
    */
@@ -21,8 +21,8 @@ public interface HashUtils
   String hash(final File file, final HashAlgorithm algorithm);
 
   /**
-   * Creates a checksum file for a given file. The hash file will be created alongside the given {@code file} in the same
-   * parent directory. Example the the file /test/1.0.jar, after calling this method with, for example
+   * Creates a checksum file for a given file. The hash file will be created alongside the given {@code file} in the
+   * same parent directory. Example the the file /test/1.0.jar, after calling this method with, for example
    * {@link HashAlgorithm#SHA512}, have alongside itself the file /test/1.0.jar.sha512
    *
    * @param file - {@link File}
@@ -44,7 +44,8 @@ public interface HashUtils
 
   /**
    * Test whether a given {@link File} is a file that is considered a signature file with .asc extension
-    * @param file - {@link File}
+   *
+   * @param file - {@link File}
    * @return true if the given file is considered a signature file
    */
   boolean isSignatureFile(File file);

--- a/src/main/java/org/sonatype/central/publisher/plugin/utils/HashUtilsImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/utils/HashUtilsImpl.java
@@ -48,7 +48,8 @@ public class HashUtilsImpl
       }
     }
     catch (IOException e) {
-      getLogger().error("Failed to generate checksum file at " + file.getAbsolutePath() + " using algorithm " + algorithm, e);
+      getLogger()
+          .error("Failed to generate checksum file at " + file.getAbsolutePath() + " using algorithm " + algorithm, e);
     }
 
     return null;

--- a/src/main/java/org/sonatype/central/publisher/plugin/utils/MojoUtilsImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/utils/MojoUtilsImpl.java
@@ -6,7 +6,6 @@ package org.sonatype.central.publisher.plugin.utils;
 
 import java.io.File;
 import java.nio.file.FileSystems;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Objects;
@@ -101,7 +100,8 @@ public class MojoUtilsImpl
 
     return FileSystems
         .getDefault()
-        .getPath(mavenSession.getExecutionRootDirectory(), DEFAULT_BUILD_DIR_NAME, relativePath).toFile();
+        .getPath(mavenSession.getExecutionRootDirectory(), DEFAULT_BUILD_DIR_NAME, relativePath)
+        .toFile();
   }
 
   private MavenProject getFirstProjectWithThisPluginDefined(
@@ -110,9 +110,11 @@ public class MojoUtilsImpl
       final String pluginArtifactId,
       final String goal)
   {
-    return mavenSession.getProjects().stream()
+    return mavenSession.getProjects()
+        .stream()
         .filter(mavenProject -> findPlugin(mavenProject.getBuild(), pluginGroupId, pluginArtifactId, goal) != null)
-        .findFirst().orElse(null);
+        .findFirst()
+        .orElse(null);
   }
 
   private boolean isCurrentTheLastProjectInExecution(final MavenSession mavenSession) {
@@ -128,8 +130,8 @@ public class MojoUtilsImpl
       final String pluginArtifactId,
       final String goal)
   {
-    return mavenSession.getCurrentProject() ==
-        getLastProjectWithMojoInExecution(mavenSession, pluginGroupId, pluginArtifactId, goal);
+    return mavenSession.getCurrentProject() == getLastProjectWithMojoInExecution(mavenSession, pluginGroupId,
+        pluginArtifactId, goal);
   }
 
   private MavenProject getLastProjectWithMojoInExecution(
@@ -141,7 +143,8 @@ public class MojoUtilsImpl
     final ArrayList<MavenProject> projects = new ArrayList<>(mavenSession.getProjects());
     Collections.reverse(projects);
     return projects.stream()
-        .filter(project -> findPlugin(project.getBuild(), pluginGroupId, pluginArtifactId, goal) != null).findFirst()
+        .filter(project -> findPlugin(project.getBuild(), pluginGroupId, pluginArtifactId, goal) != null)
+        .findFirst()
         .orElse(null);
   }
 
@@ -152,8 +155,11 @@ public class MojoUtilsImpl
       final String goal)
   {
     if (container != null) {
-      return container.getPlugins().stream()
-          .filter(plugin -> pluginMatches(plugin, pluginGroupId, pluginArtifactId, goal)).findFirst().orElse(null);
+      return container.getPlugins()
+          .stream()
+          .filter(plugin -> pluginMatches(plugin, pluginGroupId, pluginArtifactId, goal))
+          .findFirst()
+          .orElse(null);
     }
     return null;
   }
@@ -166,7 +172,8 @@ public class MojoUtilsImpl
   {
     if (expectedPluginGroupId.equals(plugin.getGroupId()) && expectedPluginArtifactId.equals(plugin.getArtifactId())) {
       if (expectedPluginGoal != null) {
-        return plugin.getExecutions().stream()
+        return plugin.getExecutions()
+            .stream()
             .anyMatch(pluginExecution -> pluginExecution.getGoals().contains(expectedPluginGoal));
       }
       return true;

--- a/src/main/java/org/sonatype/central/publisher/plugin/utils/ProjectUtils.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/utils/ProjectUtils.java
@@ -16,15 +16,16 @@ import org.apache.maven.project.MavenProject;
 
 public interface ProjectUtils
 {
-  List<ArtifactWithFile> getArtifacts(final MavenProject mavenProject, final ArtifactFactory artifactFactory)
-      throws MojoExecutionException;
+  List<ArtifactWithFile> getArtifacts(
+      final MavenProject mavenProject,
+      final ArtifactFactory artifactFactory) throws MojoExecutionException;
 
   /**
    * Delete {@link ProjectUtilsImpl#MAVEN_METADATA_CENTRAL_STAGING_XML} from the Group and Artifact ID directory of a
    * {@link MavenProject} within the given {@code sourceDir} If the {@link MavenProject} has a parent and is a module,
    * the parent and its child modules will have the xml removed as well.
    *
-   * @param project   - {@link MavenProject}
+   * @param project - {@link MavenProject}
    * @param sourceDir - {@link Path}
    */
   void deleteGroupArtifactMavenMetadataCentralStagingXml(final MavenProject project, final Path sourceDir);
@@ -36,8 +37,8 @@ public interface ProjectUtils
    * <p>
    * This method doesn't recursively go through child folders.
    *
-   * @param project         - {@link MavenProject}
-   * @param sourceDir       - {@link Path}
+   * @param project - {@link MavenProject}
+   * @param sourceDir - {@link Path}
    * @param checksumRequest - {@link ChecksumRequest}
    */
   void createChecksumFiles(final MavenProject project, final Path sourceDir, final ChecksumRequest checksumRequest);

--- a/src/main/java/org/sonatype/central/publisher/plugin/utils/ProjectUtilsImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/utils/ProjectUtilsImpl.java
@@ -39,8 +39,7 @@ public class ProjectUtilsImpl
 
   public List<ArtifactWithFile> getArtifacts(
       final MavenProject mavenProject,
-      final ArtifactFactory artifactFactory)
-      throws MojoExecutionException
+      final ArtifactFactory artifactFactory) throws MojoExecutionException
   {
     final List<ArtifactWithFile> artifactWithFiles = new ArrayList<>();
 
@@ -64,7 +63,11 @@ public class ProjectUtilsImpl
   }
 
   @Override
-  public void createChecksumFiles(final MavenProject project, final Path sourceDir, final ChecksumRequest checksumRequest) {
+  public void createChecksumFiles(
+      final MavenProject project,
+      final Path sourceDir,
+      final ChecksumRequest checksumRequest)
+  {
     Path path = getProjectGroupArtifactVersionPath(project);
     getLogger().info("Generate checksums for dir: " + path.toString());
     File gavDirectory = sourceDir.resolve(path).toFile();
@@ -147,8 +150,7 @@ public class ProjectUtilsImpl
 
   private List<ArtifactWithFile> getArtifactsFromNonPomProject(
       final MavenProject mavenProject,
-      final ArtifactFactory artifactFactory)
-      throws MojoExecutionException
+      final ArtifactFactory artifactFactory) throws MojoExecutionException
   {
     Artifact artifact = mavenProject.getArtifact();
     List<Artifact> attachedArtifacts = mavenProject.getAttachedArtifacts();
@@ -184,8 +186,10 @@ public class ProjectUtilsImpl
   }
 
   private List<ArtifactWithFile> getAttachedArtifacts(final MavenProject mavenProject) {
-    return mavenProject.getAttachedArtifacts().stream()
-        .map(artifact -> new ArtifactWithFile(artifact.getFile(), artifact)).collect(toList());
+    return mavenProject.getAttachedArtifacts()
+        .stream()
+        .map(artifact -> new ArtifactWithFile(artifact.getFile(), artifact))
+        .collect(toList());
   }
 
   private void deleteMavenMetadataCentralStagingXml(final MavenProject project, final Path sourceDir) {

--- a/src/main/java/org/sonatype/central/publisher/plugin/watcher/DeploymentPublishedWatcherImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/watcher/DeploymentPublishedWatcherImpl.java
@@ -38,7 +38,8 @@ public class DeploymentPublishedWatcherImpl
   private PurlUtils purlUtils;
 
   @SuppressWarnings("unused") // used via reflection by Plexus
-  public DeploymentPublishedWatcherImpl() { }
+  public DeploymentPublishedWatcherImpl() {
+  }
 
   DeploymentPublishedWatcherImpl(PublisherClient publisherClient, PurlUtils purlUtils) {
     this.publisherClient = publisherClient;
@@ -57,8 +58,8 @@ public class DeploymentPublishedWatcherImpl
         "Waiting until Deployment %s is %s", deploymentId, waitForDeploymentStateRequest.waitTypeName()));
 
     try {
-      while (Duration.between(start, Instant.now()).get(SECONDS) <
-          waitForDeploymentStateRequest.getWaitMaxTimeInSeconds()) {
+      while (Duration.between(start, Instant.now()).get(SECONDS) < waitForDeploymentStateRequest
+          .getWaitMaxTimeInSeconds()) {
 
         // convert to milliseconds
         Integer interval = waitForDeploymentStateRequest.getWaitPollingIntervalInSeconds() * 1000;
@@ -160,7 +161,6 @@ public class DeploymentPublishedWatcherImpl
         "Deployment %s has been %s. To finish publishing visit %s/publishing/deployments",
         deploymentId,
         waitForDeploymentStateRequest.waitTypeName(),
-        waitForDeploymentStateRequest.getCentralBaseUrl()
-    ));
+        waitForDeploymentStateRequest.getCentralBaseUrl()));
   }
 }

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,29 @@
+ <site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>2.1.0</version>
+    </skin>
+    <bannerLeft name="${project.name}" />
+    <custom>
+        <fluidoSkin>
+            <topBarEnabled>true</topBarEnabled>
+            <sideBarEnabled>true</sideBarEnabled>
+            <gitHub>
+                <projectId>mavenplugins/central-publishing-maven-plugin</projectId>
+                <ribbonOrientation>right</ribbonOrientation>
+                <ribbonColor>gray</ribbonColor>
+            </gitHub>
+        </fluidoSkin>
+    </custom>
+
+    <body>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html"/>
+            <item name="Goals" href="plugin-info.html"/>
+            <!-- <item name="Usage" href="usage.html"/> -->
+        </menu>
+        <menu ref="reports" inherit="top"/>
+    </body>
+</site>


### PR DESCRIPTION
### Changes
- Update .java code formatted with `mvn spotless:apply`
- Add Sonatype code style definition files
  - sonatype/codestyle/sonatype-eclipse.xml:
    - taken from https://raw.githubusercontent.com/sonatype/nexus-public/refs/heads/main/sonatype-config/sonatype-eclipse.xml
  - sonatype/codestyle/sonatype-eclipse-imports.importorder:
    - taken from https://raw.githubusercontent.com/sonatype/codestyle/refs/heads/main/sonatype-eclipse-imports.importorder
  - sonatype/codestyle/ReadMe.txt:
    - contains information about the source of the files above
 - Add Maven site configuration file
  - add src/site/site.xml
- Enhance build procedure with code format checking and Maven site building
  - pom.xml:
    - enhance Maven compiler config:
      <maven.compiler.showDeprecation>false</maven.compiler.showDeprecation>
      <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
    - add com.diffplug.spotless:spotless-maven-plugin:2.46.1
      - configured for Sonatype code style
      - add execution of goal 'check' in phase 'compile'
    - bump plugin versions:
      <version.maven-compiler-plugin>3.12.1</version.maven-compiler-plugin>
      <version.maven-javadoc-plugin>3.6.0</version.maven-javadoc-plugin>
      <version.maven-plugin-report-plugin>4.0.0-beta-1</version.maven-plugin-report-plugin>
      <version.maven-project-info-reports-plugin>3.9.0</version.maven-project-info-reports-plugin>
      <version.maven-site-plugin>3.21.0</version.maven-site-plugin>
    - add definitions for Maven site building:
      - add plugin management for:
        - maven-plugin-report-plugin
        - maven-project-info-reports-plugin
        - maven-site-plugin
      - add node <reporting>...</reporting>
  - .mvn/config:
    - add Maven JVM configuration to run Maven with JDK 11+



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - CI workflows pinned to Java 17 and Maven 3.9.6; JVM options added to improve reflective access.
- Documentation
  - Added Maven Site with Fluido skin, navigation and GitHub ribbon.
  - Added code style README and Eclipse formatter/import-order configs.
- Style
  - Introduced Spotless automated formatting and enforced checks during build.
  - Applied consistent formatting across the codebase and removed unused imports.
- Build
  - Standardized Maven plugin versions and added a Javadoc lint profile for consistent builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->