### PR TITLE
Add missing plugin parameter descriptions, improve code to prevent NPE

### DIFF
--- a/src/main/java/org/sonatype/central/publisher/plugin/AbstractPublisherMojo.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/AbstractPublisherMojo.java
@@ -18,9 +18,16 @@ import org.apache.maven.plugins.annotations.Parameter;
 public abstract class AbstractPublisherMojo
     extends AbstractMojo
 {
+  /**
+   * For creating only the bundle but skipping uploading and publishing. This is useful for creating a bundle and
+   * manually uploading it through <code>central.sonatype.com</code>.
+   */
   @Parameter(property = "skipPublishing", defaultValue = "false", required = true)
   private boolean skipPublishing;
 
+  /**
+   * Indicates if building is allowed to have the plugin fail before uploading and publishing occurs.
+   */
   @Parameter(property = "failOnBuildFailure", defaultValue = "true")
   private boolean failOnBuildFailure;
 


### PR DESCRIPTION
- AbstractPublisherMojo.java, PublishMojo.java:
  - add missing parameter Javadoc / descriptions. Taken from https://central.sonatype.org/publish/publish-portal-maven/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Configure the bundle output filename.
  - Override working, staging, and deferred directories via properties.
  - Add autoPublish option to control automatic vs. user-managed publishing.

- Documentation
  - Expanded docs for waitUntil (uploaded, validated, published), checksum options (all, required, none), and centralSnapshotsUrl precedence.
  - Clarified deploymentName, skipPublishing (bundle-only), and failOnBuildFailure.

- Bug Fixes
  - Improved credential validation with clearer error messages when server/credentials are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->