### PR TITLE
Enhance Mojo `publish`: add config parameter `dropValidated`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -619,12 +619,7 @@
         <!-- Sonatype staging -->
         <!-- staging.autoPublish: should be set to false for testing on release version deployments. -->
         <staging.autoPublish>true</staging.autoPublish>
-        <staging.dropPhaseNever>_NEVER_</staging.dropPhaseNever>
-        <staging.dropPhaseDeploy>deploy</staging.dropPhaseDeploy>
-        <!-- Note: staging.dropPhase: must be either ${staging.dropPhaseNever} or ${staging.dropPhaseDeploy} -->
-        <!-- It should be overridden e.g. for testing on artifact release version deployments. -->
-        <!-- <staging.dropPhase>${staging.dropPhaseNever}</staging.dropPhase> -->
-        <staging.dropPhase>_NEVER_</staging.dropPhase>
+        <staging.dropValidated>false</staging.dropValidated>
         <staging.publishPhase>deploy</staging.publishPhase>
         <!-- Maximum amount of seconds to waitUntil a state has been reached. Cannot be less than 1800 seconds. -->
         <staging.progressTimeoutSeconds>1817</staging.progressTimeoutSeconds>
@@ -902,8 +897,9 @@
       </activation>
       <properties>
         <staging.autoPublish>false</staging.autoPublish>
+        <staging.dropValidated>true</staging.dropValidated>
         <staging.waitUntil>${staging.waitUntilValidatedState}</staging.waitUntil>
-        <staging.dropPhase>${staging.dropPhaseDeploy}</staging.dropPhase>
+        <version.central-publishing-maven-plugin.forStaging>${project.version}</version.central-publishing-maven-plugin.forStaging>
       </properties>
     </profile>
     <profile>
@@ -916,8 +912,8 @@
       </activation>
       <properties>
         <staging.autoPublish>false</staging.autoPublish>
+        <staging.dropValidated>false</staging.dropValidated>
         <staging.waitUntil>${staging.waitUntilValidatedState}</staging.waitUntil>
-        <staging.dropPhase>${staging.dropPhaseNever}</staging.dropPhase>
         <organization.stagingServerId>${organization.snapshotNexusRepoId}</organization.stagingServerId>
         <groupId.central-publishing-maven-plugin.forStaging>${project.groupId}</groupId.central-publishing-maven-plugin.forStaging>
         <version.central-publishing-maven-plugin.forStaging>${project.version}</version.central-publishing-maven-plugin.forStaging>
@@ -964,6 +960,7 @@
                  published, uploaded, validated -->
               <waitUntil>${staging.waitUntil}</waitUntil>
               <autoPublish>${staging.autoPublish}</autoPublish>
+              <dropValidated>${staging.dropValidated}</dropValidated>
               <checksums>all</checksums>
             </configuration>
             <executions>
@@ -977,15 +974,6 @@
                   <goal>publish</goal>
                 </goals>
               </execution>
-              <!-- With central-publishing-maven-plugin there is no dropping anymore. -->
-              <!-- Validated but not published deployments will be removed after 90 days. -->
-              <!-- <execution>-->
-              <!--   <id>STAGING_EXPLICIT_DROP_AFTER_DEPLOY</id>-->
-              <!--   <phase>${staging.dropPhase}</phase>-->
-              <!--   <goals>-->
-              <!--     <goal>drop</goal>-->
-              <!--   </goals>-->
-              <!-- </execution>-->
             </executions>
           </plugin>
         </plugins>

--- a/src/main/java/org/sonatype/central/publisher/client/PublisherClient.java
+++ b/src/main/java/org/sonatype/central/publisher/client/PublisherClient.java
@@ -24,6 +24,8 @@ public interface PublisherClient
 
   DeploymentApiResponse status(final String deploymentId);
 
+  void delete(final String deploymentId);
+
   boolean isPublished(final String namespace, final String name, final String version);
 
   /**

--- a/src/main/java/org/sonatype/central/publisher/client/PublisherClientFactory.java
+++ b/src/main/java/org/sonatype/central/publisher/client/PublisherClientFactory.java
@@ -5,6 +5,7 @@
 package org.sonatype.central.publisher.client;
 
 import org.sonatype.central.publisher.client.httpclient.ComponentPublishedEndpoint;
+import org.sonatype.central.publisher.client.httpclient.DeletePublisherEndpoint;
 import org.sonatype.central.publisher.client.httpclient.StatusPublisherEndpoint;
 import org.sonatype.central.publisher.client.httpclient.UploadPublisherEndpoint;
 import org.sonatype.central.publisher.client.httpclient.auth.AuthProviderFactory;
@@ -16,6 +17,6 @@ public final class PublisherClientFactory
 
   public static PublisherClient createPublisherClient() {
     return new PublisherClientImpl(new UploadPublisherEndpoint(), new StatusPublisherEndpoint(),
-        new ComponentPublishedEndpoint(), new AuthProviderFactory());
+        new ComponentPublishedEndpoint(), new DeletePublisherEndpoint(), new AuthProviderFactory());
   }
 }

--- a/src/main/java/org/sonatype/central/publisher/client/PublisherClientImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/client/PublisherClientImpl.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import org.sonatype.central.publisher.client.httpclient.ComponentPublishedEndpoint;
+import org.sonatype.central.publisher.client.httpclient.DeletePublisherEndpoint;
 import org.sonatype.central.publisher.client.httpclient.StatusPublisherEndpoint;
 import org.sonatype.central.publisher.client.httpclient.UploadPublisherEndpoint;
 import org.sonatype.central.publisher.client.httpclient.auth.AuthProvider;
@@ -39,17 +40,21 @@ class PublisherClientImpl
 
   private final ComponentPublishedEndpoint componentPublishedEndpoint;
 
+  private final DeletePublisherEndpoint deletePublisherEndpoint;
+
   private final AuthProviderFactory authProviderFactory;
 
   public PublisherClientImpl(
       final UploadPublisherEndpoint uploadPublisherEndpoint,
       final StatusPublisherEndpoint statusPublisherEndpoint,
       final ComponentPublishedEndpoint componentPublishedEndpoint,
+      final DeletePublisherEndpoint deletePublisherEndpoint,
       final AuthProviderFactory authProviderFactory)
   {
     this.uploadPublisherEndpoint = uploadPublisherEndpoint;
     this.statusPublisherEndpoint = statusPublisherEndpoint;
     this.componentPublishedEndpoint = componentPublishedEndpoint;
+    this.deletePublisherEndpoint = deletePublisherEndpoint;
     this.authProviderFactory = authProviderFactory;
   }
 
@@ -84,6 +89,12 @@ class PublisherClientImpl
     Map<String, String> queryParams = authProvider().getQueryParams();
     queryParams.put(DEPLOYMENT_ID_QUERY_PARAM, deploymentId);
     return statusPublisherEndpoint.call(centralBaseUrl(), authProvider(), queryParams);
+  }
+
+  @Override
+  public void delete(final String deploymentId) {
+    Map<String, String> queryParams = authProvider().getQueryParams();
+    deletePublisherEndpoint.call(centralBaseUrl(), authProvider(), queryParams, deploymentId);
   }
 
   @Override

--- a/src/main/java/org/sonatype/central/publisher/client/PublisherConstants.java
+++ b/src/main/java/org/sonatype/central/publisher/client/PublisherConstants.java
@@ -15,6 +15,8 @@ public class PublisherConstants
 
   public static final String PUBLISHED_ENDPOINT_URL = "/api/v1/publisher/published";
 
+  public static final String DELETE_ENDPOINT_URL = "/api/v1/publisher/deployment/%s";
+
   public static final String HTTP_AUTHORIZATION_HEADER = "Authorization";
 
   public static final String HTTP_USERTOKEN_AUTH_SCHEME = "UserToken";

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/DeletePublisherEndpoint.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/DeletePublisherEndpoint.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.client.httpclient;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.sonatype.central.publisher.client.httpclient.auth.AuthProvider;
+
+import org.apache.hc.client5.http.HttpResponseException;
+
+import static java.lang.String.format;
+import static org.sonatype.central.publisher.client.PublisherConstants.DELETE_ENDPOINT_URL;
+import static org.sonatype.central.publisher.client.httpclient.PublisherHttpClient.sendRequest;
+import static org.sonatype.central.publisher.client.httpclient.RequestType.DELETE;
+import static org.sonatype.central.publisher.client.httpclient.utils.HttpResponseUtil.toContentString;
+
+public class DeletePublisherEndpoint
+{
+  public void call(
+      final String baseUrl,
+      final AuthProvider authProvider,
+      final Map<String, String> params,
+      final String deploymentId)
+  {
+    try {
+      sendRequest(authProvider, baseUrl + format(DELETE_ENDPOINT_URL, deploymentId), params, null, DELETE);
+    }
+    catch (HttpResponseException e) {
+      throw new RuntimeException("Cannot delete deployment. Response status code: "
+          + e.getStatusCode()
+          + " response message: "
+          + toContentString(e));
+    }
+    catch (IOException e) {
+      throw new RuntimeException("Invalid request. " + e.getMessage());
+    }
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/PublisherHttpClient.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/PublisherHttpClient.java
@@ -13,8 +13,10 @@ import java.util.Map;
 
 import org.sonatype.central.publisher.client.httpclient.auth.AuthProvider;
 
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.client5.http.entity.mime.HttpMultipartMode;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.client5.http.impl.classic.BasicHttpClientResponseHandler;
@@ -54,11 +56,13 @@ public class PublisherHttpClient
           }
         }
         case GET:
+        case DELETE:
         default: {
-          HttpGet httpGet = new HttpGet(uriBuilder.build());
-          authProvider.getAuthHeaders().forEach(httpGet::addHeader);
+          HttpUriRequestBase httpRequest =
+              requestType == RequestType.DELETE ? new HttpDelete(uriBuilder.build()) : new HttpGet(uriBuilder.build());
+          authProvider.getAuthHeaders().forEach(httpRequest::addHeader);
           try (CloseableHttpClient client = HttpClients.createDefault()) {
-            return client.execute(httpGet, new BasicHttpClientResponseHandler());
+            return client.execute(httpRequest, new BasicHttpClientResponseHandler());
           }
         }
       }

--- a/src/main/java/org/sonatype/central/publisher/client/httpclient/RequestType.java
+++ b/src/main/java/org/sonatype/central/publisher/client/httpclient/RequestType.java
@@ -8,5 +8,6 @@ package org.sonatype.central.publisher.client.httpclient;
 public enum RequestType
 {
   POST,
-  GET
+  GET,
+  DELETE
 }

--- a/src/main/java/org/sonatype/central/publisher/plugin/AbstractPublisherMojo.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/AbstractPublisherMojo.java
@@ -21,12 +21,16 @@ public abstract class AbstractPublisherMojo
   /**
    * For creating only the bundle but skipping uploading and publishing. This is useful for creating a bundle and
    * manually uploading it through <code>central.sonatype.com</code>.
+   *
+   * @since 0.1.1
    */
   @Parameter(property = "skipPublishing", defaultValue = "false", required = true)
   private boolean skipPublishing;
 
   /**
    * Indicates if building is allowed to have the plugin fail before uploading and publishing occurs.
+   *
+   * @since 0.1.1
    */
   @Parameter(property = "failOnBuildFailure", defaultValue = "true")
   private boolean failOnBuildFailure;

--- a/src/main/java/org/sonatype/central/publisher/plugin/Constants.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/Constants.java
@@ -50,6 +50,10 @@ public class Constants
 
   public static final String AUTO_PUBLISH_DEFAULT_VALUE = "false";
 
+  public static final String DROP_VALIDATED_NAME = "dropValidated";
+
+  public static final String DROP_VALIDATED_DEFAULT_VALUE = "false";
+
   public static final String WAIT_UNTIL_NAME = "waitUntil";
 
   public static final String WAIT_UNTIL_DEFAULT_VALUE = "VALIDATED";

--- a/src/main/java/org/sonatype/central/publisher/plugin/PublishMojo.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/PublishMojo.java
@@ -92,6 +92,8 @@ public class PublishMojo
 {
   /**
    * Name of the bundle file that the plugin will output as a result.
+   *
+   * @since 0.1.1
    */
   @Parameter(property = "outputFilename", defaultValue = DEFAULT_BUNDLE_OUTPUT_FILENAME, required = true)
   private String outputFilename;
@@ -99,6 +101,8 @@ public class PublishMojo
   /**
    * Name of the directory that the plugin will output the bundle file into.<br>
    * <b>Note:</b> this directory will be cleaned on the first execution of this plugin.
+   *
+   * @since 0.1.1
    */
   @Parameter(property = "outputDirectory")
   private File forcedOutputDirectory;
@@ -106,6 +110,8 @@ public class PublishMojo
   /**
    * Name of the directory where the plugin will stage files.<br>
    * <b>Note:</b> this directory will be cleaned on the first execution of this plugin.
+   *
+   * @since 0.1.1
    */
   @Parameter(property = "stagingDirectory")
   private File forcedStagingDirectory;
@@ -113,6 +119,8 @@ public class PublishMojo
   /**
    * Name of the directory where the plugin will defer snapshot files.<br>
    * <b>Note:</b> this directory will be cleaned on the first execution of this plugin.
+   *
+   * @since 0.7.0
    */
   @Parameter(property = "deferredDirectory")
   private File forcedDeferredDirectory;
@@ -120,12 +128,16 @@ public class PublishMojo
   /**
    * Name of the deployment that's used for uploading and deploying on the central url. If using
    * <code>central.sonatype.com</code>, this is the name that will be visible on the Deployments page.
+   *
+   * @since 0.1.1
    */
   @Parameter(property = "deploymentName", defaultValue = DEFAULT_DEPLOYMENT_NAME)
   private String deploymentName;
 
   /**
    * ID of the server that you configured in your <code>settings.xml</code>.
+   *
+   * @since 0.1.1
    */
   @Parameter(property = PUBLISHING_SERVER_ID_NAME, defaultValue = PUBLISHING_SERVER_ID_DEFAULT_VALUE)
   private String publishingServerId;
@@ -133,6 +145,8 @@ public class PublishMojo
   /**
    * Assign whether to auto publish a deployment. Meaning that no manual intervention is required, if a deployment is
    * considered valid, before publishing it. Defaults to {@link Constants#AUTO_PUBLISH_DEFAULT_VALUE}.
+   *
+   * @since 0.2.0
    */
   @Parameter(property = AUTO_PUBLISH_NAME, defaultValue = AUTO_PUBLISH_DEFAULT_VALUE)
   private boolean autoPublish;
@@ -158,6 +172,8 @@ public class PublishMojo
    * <code>published</code> - Wait until the uploaded bundle is published to Maven Central.
    * <p/>
    * Defaults to {@link Constants#WAIT_UNTIL_DEFAULT_VALUE}.
+   *
+   * @since 0.2.0
    */
   @Parameter(
       property = WAIT_UNTIL_NAME,
@@ -167,6 +183,8 @@ public class PublishMojo
   /**
    * Assign the amount of seconds that the plugin will wait for a deployment state. Can not be less than
    * {@link Constants#WAIT_MAX_TIME_DEFAULT_VALUE}.
+   *
+   * @since 0.2.0
    */
   @Parameter(
       property = WAIT_MAX_TIME_NAME,
@@ -176,6 +194,8 @@ public class PublishMojo
   /**
    * Assign the amount of seconds between checking whether a deployment has published. Can not be less than
    * {@link Constants#WAIT_POLLING_INTERVAL_DEFAULT_VALUE}.
+   *
+   * @since 0.2.0
    */
   @Parameter(
       property = WAIT_POLLING_INTERVAL_NAME,
@@ -184,6 +204,8 @@ public class PublishMojo
 
   /**
    * @deprecated use {@link #waitPollingInterval} instead
+   *
+   * @since 0.1.1
    */
   @Deprecated
   @Parameter(
@@ -193,6 +215,8 @@ public class PublishMojo
 
   /**
    * @deprecated use {@link #autoPublish} in combination with {@link #waitUntil} instead
+   *
+   * @since 0.1.1
    */
   @Deprecated
   @Parameter(property = WAIT_FOR_PUBLISH_COMPLETION_NAME, defaultValue = WAIT_FOR_PUBLISH_COMPLETION_DEFAULT_VALUE)
@@ -201,6 +225,8 @@ public class PublishMojo
   /**
    * Assign the URL that this plugin uses to publish releases. Defaults to
    * {@link Constants#CENTRAL_BASE_URL_DEFAULT_VALUE}.
+   *
+   * @since 0.1.1
    */
   @Parameter(property = CENTRAL_BASE_URL_NAME, defaultValue = CENTRAL_BASE_URL_DEFAULT_VALUE)
   private String centralBaseUrl;
@@ -214,6 +240,8 @@ public class PublishMojo
    * b) Use repo URL defined by distributionManagement from project POM if this is defined.
    * <p/>
    * c) Use {@link Constants#CENTRAL_SNAPSHOTS_URL_DEFAULT_VALUE} as default if {@link #publishingServerId} is set.
+   *
+   * @since 0.7.0
    */
   @Parameter(property = CENTRAL_SNAPSHOTS_URL_NAME)
   private String centralSnapshotsUrl;
@@ -227,6 +255,8 @@ public class PublishMojo
    * <p/>
    * <code>none</code> - No Checksums will be requested to be generated.
    * <p/>
+   *
+   * @since 0.1.1
    */
   @Parameter(property = CHECKSUMS_NAME, defaultValue = CHECKSUMS_DEFAULT_VALUE)
   private String checksums;
@@ -238,12 +268,16 @@ public class PublishMojo
    * new version X.Y.1 of child2, but leave child1 and parent unchanged), this setting will assure that previous
    * published components will not be published again, which will cause the publishing to fail. Defaults to
    * {@link Constants#IGNORE_PUBLISHED_COMPONENTS_DEFAULT_VALUE}.
+   *
+   * @since 0.1.6
    */
   @Parameter(property = IGNORE_PUBLISHED_COMPONENTS_NAME, defaultValue = IGNORE_PUBLISHED_COMPONENTS_DEFAULT_VALUE)
   private boolean ignorePublishedComponents;
 
   /**
    * Assign artifacts that must not be added to the bundle that represents the deployment that will be published.
+   *
+   * @since 0.1.6
    */
   @Parameter(property = EXCLUDE_ARTIFACTS_NAME)
   private List<String> excludeArtifacts = new ArrayList<>();

--- a/src/main/java/org/sonatype/central/publisher/plugin/deleter/DeploymentDeleter.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/deleter/DeploymentDeleter.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.plugin.deleter;
+
+import org.sonatype.central.publisher.plugin.model.DeleteDeploymentRequest;
+
+public interface DeploymentDeleter
+{
+  void deleteDeployment(
+      final DeleteDeploymentRequest deleteDeploymentRequest);
+}

--- a/src/main/java/org/sonatype/central/publisher/plugin/deleter/DeploymentDeleterImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/deleter/DeploymentDeleterImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.plugin.deleter;
+
+import org.sonatype.central.publisher.client.PublisherClient;
+import org.sonatype.central.publisher.client.PublisherClientFactory;
+import org.sonatype.central.publisher.plugin.exceptions.DeploymentDeleteFailedException;
+import org.sonatype.central.publisher.plugin.model.DeleteDeploymentRequest;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.AbstractLogEnabled;
+
+import static java.lang.String.format;
+
+@Component(role = DeploymentDeleter.class)
+public class DeploymentDeleterImpl
+    extends AbstractLogEnabled
+    implements DeploymentDeleter
+{
+  @Requirement
+  private PublisherClient publisherClient;
+
+  @SuppressWarnings("unused") // used via reflection by Plexus
+  public DeploymentDeleterImpl() {
+  }
+
+  DeploymentDeleterImpl(final PublisherClient publisherClient) {
+    this.publisherClient = publisherClient != null ? publisherClient : PublisherClientFactory.createPublisherClient();
+  }
+
+  @Override
+  public void deleteDeployment(DeleteDeploymentRequest deleteDeploymentRequest) {
+    if (getLogger() != null) {
+      getLogger().info("Going to delete deployment " + deleteDeploymentRequest.getDeploymentId());
+    }
+
+    try {
+      publisherClient.delete(
+          deleteDeploymentRequest.getDeploymentId());
+
+      if (getLogger() != null) {
+        getLogger().info(
+            format("Deleted deployment successfully, deployment name: %s, deploymentId: %s.",
+                deleteDeploymentRequest.getDeploymentName(), deleteDeploymentRequest.getDeploymentId()));
+      }
+    }
+    catch (Exception e) {
+      if (getLogger() != null) {
+        getLogger().error(format("Unable to delete deployment name: %s, deploymentId: %s",
+            deleteDeploymentRequest.getDeploymentName(), deleteDeploymentRequest.getDeploymentId()), e);
+      }
+
+      throw new DeploymentDeleteFailedException(deleteDeploymentRequest);
+    }
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/plugin/exceptions/DeploymentDeleteFailedException.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/exceptions/DeploymentDeleteFailedException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+
+package org.sonatype.central.publisher.plugin.exceptions;
+
+import org.sonatype.central.publisher.plugin.model.DeleteDeploymentRequest;
+
+public class DeploymentDeleteFailedException
+    extends RuntimeException
+{
+  public DeploymentDeleteFailedException(final DeleteDeploymentRequest deleteDeploymentRequest) {
+    super("Deployment " + deleteDeploymentRequest.getDeploymentId()
+        + " (" + deleteDeploymentRequest.getDeploymentName() + ") failed while deleting");
+  }
+}

--- a/src/main/java/org/sonatype/central/publisher/plugin/model/DeleteDeploymentRequest.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/model/DeleteDeploymentRequest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022-present Sonatype, Inc. All rights reserved.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+package org.sonatype.central.publisher.plugin.model;
+
+/**
+ * Simple class to wrap common request values for requesting to delete a Deployment.
+ */
+public class DeleteDeploymentRequest
+{
+  private final String deploymentId;
+
+  private final String deploymentName;
+
+  public DeleteDeploymentRequest(String deploymentId, String deploymentName) {
+    this.deploymentId = deploymentId;
+    this.deploymentName = deploymentName;
+  }
+
+  public String getDeploymentId() {
+    return deploymentId;
+  }
+
+  public String getDeploymentName() {
+    return deploymentName;
+  }
+}


### PR DESCRIPTION
## Changes

- add classes:
  - DeletePublisherEndpoint.java
  - DeploymentDeleter.java
  - DeploymentDeleterImpl.java
  - DeploymentDeleteFailedException.java
  - DeleteDeploymentRequest.java

- PublisherClient.java:
  - add method
    void delete(final String deploymentId)

- PublisherClientImpl.java:
  - add field DeletePublisherEndpoint deletePublisherEndpoint
  - enhance cTor accordingly
  - add method
    void delete(final String deploymentId)

- PublisherClientFactory.java:
  - add DeletePublisherEndpoint to cTor of PublisherClientImpl

- PublisherConstants.java:
  - add DELETE_ENDPOINT_URL

- RequestType.java:
  - add DELETE

- PublisherHttpClient.java:
  - add DELETE request

- Constants.java:
  - add DROP_VALIDATED_NAME
  - add DROP_VALIDATED_DEFAULT_VALUE

- PublishMojo.java:
  - add parameter dropValidated
  - enhance parameter validation
  - enhance postProcessRelease
    to delete deployment if dropValidated is effective enabled
  - add missing `@since` to parameter documentation

- pom.xml:
  - enhance to drop deployment in case of
    env.DO_NOT_RELEASE_SONATYPE_STAGING == true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dropValidated option to optionally auto-delete deployments after they reach VALIDATED (enforced when autoPublish is off).
  * Added a public delete operation and a deployment deletion component to remove validated deployments.

* **Refactor**
  * Simplified staging configuration: replaced phase-based drop controls with a single dropValidated flag and unified staging plugin version mapping.

* **Improvements**
  * Added HTTP DELETE support to the client and adjusted staging wait behavior per profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->