### PR TITLE
feat: add skipBundling option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ buildNumber.properties
 .classpath
 # Eclipse settings to be managed by Oomph
 .settings/
+
+# IntelliJ IDEA
+.idea/

--- a/src/main/java/org/sonatype/central/publisher/plugin/AbstractPublisherMojo.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/AbstractPublisherMojo.java
@@ -28,6 +28,15 @@ public abstract class AbstractPublisherMojo
   private boolean skipPublishing;
 
   /**
+   * For skipping artifacts bundling.
+   +
+   + This is particularly useful for multi-module build, where some sub-modules should
+   + not be included in the final bundle that will be uploaded to <code>central.sonatype.com</code>.
+   */
+  @Parameter(property = "skipBundling", defaultValue = "false", required = false)
+  private boolean skipBundling;
+
+  /**
    * Indicates if building is allowed to have the plugin fail before uploading and publishing occurs.
    *
    * @since 0.1.1
@@ -93,6 +102,10 @@ public abstract class AbstractPublisherMojo
 
   protected boolean isSkipPublishing() {
     return skipPublishing;
+  }
+
+  protected boolean isSkipBundling() {
+    return skipBundling;
   }
 
   protected String getPluginGav() {

--- a/src/main/java/org/sonatype/central/publisher/plugin/PublishMojo.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/PublishMojo.java
@@ -499,6 +499,11 @@ public class PublishMojo
       final List<ArtifactWithFile> artifactWithFiles,
       final File deferredDirectory) throws MojoExecutionException
   {
+    if (isSkipBundling()) {
+      getLog().info("Skipping bundling of artifacts at user's request.");
+      return;
+    }
+
     List<ArtifactWithFile> filteredArtifactWithFiles = artifactWithFiles.stream()
         .filter(artifactWithFile -> !excludeArtifacts.contains(artifactWithFile.getArtifact().getArtifactId()))
         .collect(toList());
@@ -521,6 +526,11 @@ public class PublishMojo
       final List<ArtifactWithFile> artifactWithFiles,
       final File stagingDirectory) throws MojoExecutionException
   {
+    if (isSkipBundling()) {
+      getLog().info("Skipping bundling of artifacts at user's request.");
+      return;
+    }
+
     List<ArtifactWithFile> filteredArtifactWithFiles = artifactWithFiles.stream()
         .filter(artifactWithFile -> {
           if (excludeArtifacts.contains(artifactWithFile.getArtifact().getArtifactId())) {


### PR DESCRIPTION
As discussed in #22, I'm adding a `skipBundling` option, the main objective being to be able to skip some artifacts from being included in the final bundle (the one uploaded to maven central).

This would be especially useful for maven multi-modules projects, where we could want to prevent some module artifacts from being published to maven central.

Example configuration:

```xml
<properties>
  <!-- Override this property on modules that should not be included in the output bundle -->
  <central.skip.bundling>false</central.skip.bundling>
</properties>

<build>
  <plugins>
    <plugin>
      <groupId>io.github.mavenplugins</groupId>
      <artifactId>central-publishing-maven-plugin</artifactId>
      <version>[VERSION]</version>
      <configuration>
        <publishingServerId>central</publishingServerId>
        <skipBundling>${central.skip.bundling}</skipBundling>
      </configuration>
      <executions>
        <execution>
          <id>publish-to-maven-central</id>
          <phase>deploy</phase>
          <goals>
            <goal>publish</goal>
          </goals>
        </execution>
      </executions>
    </plugin>
  </plugin>
</build>
```