### PR TITLE
Bump unleash scm git plugin version to 3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -666,7 +666,7 @@
         <groupId.unleash-scm-provider>${groupId.unleash.common}</groupId.unleash-scm-provider>
         <groupId.unleash-scm-provider-git>${groupId.unleash-scm-provider}</groupId.unleash-scm-provider-git>
         <artifactId.unleash-scm-provider-git>unleash-scm-provider-git</artifactId.unleash-scm-provider-git>
-        <version.unleash-scm-provider-git>3.3.0</version.unleash-scm-provider-git>
+        <version.unleash-scm-provider-git>3.3.1</version.unleash-scm-provider-git>
         <groupId.unleash-scm-provider-svn>${groupId.unleash-scm-provider}</groupId.unleash-scm-provider-svn>
         <artifactId.unleash-scm-provider-svn>unleash-scm-provider-svn</artifactId.unleash-scm-provider-svn>
         <version.unleash-scm-provider-svn>3.0.2</version.unleash-scm-provider-svn>


### PR DESCRIPTION
- pom.xml:
  - bump version.unleash-scm-provider-git to 3.3.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git SCM provider dependency to the latest patch version for improved compatibility and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->