### PR TITLE
fix: use Maven 4 consumer POM instead of build POM

### DIFF
--- a/src/main/java/org/sonatype/central/publisher/plugin/utils/ProjectUtilsImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/utils/ProjectUtilsImpl.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.sonatype.central.publisher.plugin.model.ArtifactWithFile;
 import org.sonatype.central.publisher.plugin.model.ChecksumRequest;
@@ -141,7 +142,8 @@ public class ProjectUtilsImpl
 
   private List<ArtifactWithFile> getArtifactsFromPomProject(final MavenProject mavenProject) {
     List<ArtifactWithFile> artifactWithFiles = new ArrayList<>();
-    artifactWithFiles.add(new ArtifactWithFile(mavenProject.getFile(), mavenProject.getArtifact()));
+    File pomFile = findConsumerPom(mavenProject).orElse(mavenProject.getFile());
+    artifactWithFiles.add(new ArtifactWithFile(pomFile, mavenProject.getArtifact()));
 
     artifactWithFiles.addAll(getAttachedArtifacts(mavenProject));
 
@@ -156,7 +158,8 @@ public class ProjectUtilsImpl
     List<Artifact> attachedArtifacts = mavenProject.getAttachedArtifacts();
     List<ArtifactWithFile> artifactWithFiles = new ArrayList<>();
 
-    artifact.addMetadata(new ProjectArtifactMetadata(artifact, mavenProject.getFile()));
+    File pomFile = findConsumerPom(mavenProject).orElse(mavenProject.getFile());
+    artifact.addMetadata(new ProjectArtifactMetadata(artifact, pomFile));
 
     final File file = artifact.getFile();
 
@@ -169,7 +172,7 @@ public class ProjectUtilsImpl
       final Artifact pomArtifact =
           artifactFactory.createProjectArtifact(artifact.getGroupId(), artifact.getArtifactId(),
               artifact.getBaseVersion());
-      pomArtifact.setFile(mavenProject.getFile());
+      pomArtifact.setFile(pomFile);
 
       artifactWithFiles.add(new ArtifactWithFile(pomArtifact.getFile(), pomArtifact));
 
@@ -185,11 +188,70 @@ public class ProjectUtilsImpl
     return artifactWithFiles;
   }
 
+  private static final String CONSUMER_CLASSIFIER = "consumer";
+
+  private static final String POM_TYPE = "pom";
+
+  private static final String POM_SIGNATURE_TYPE = "pom.asc";
+
+  /**
+   * Collect attached artifacts, replacing Maven 4 consumer POM artifacts with their proper roles.
+   * Single-pass over attached artifacts to classify and transform them.
+   */
   private List<ArtifactWithFile> getAttachedArtifacts(final MavenProject mavenProject) {
-    return mavenProject.getAttachedArtifacts()
+    File consumerPomSignatureFile = null;
+    List<Artifact> regularArtifacts = new ArrayList<>();
+
+    for (Artifact artifact : mavenProject.getAttachedArtifacts()) {
+      if (isConsumerPom(artifact) || isConsumerPomSignature(artifact)) {
+        if (isConsumerPomSignature(artifact)) {
+          consumerPomSignatureFile = artifact.getFile();
+        }
+        // consumer POM and its signature are excluded from regular artifacts
+      }
+      else {
+        regularArtifacts.add(artifact);
+      }
+    }
+
+    final File pomSignatureReplacement = consumerPomSignatureFile;
+    return regularArtifacts
         .stream()
-        .map(artifact -> new ArtifactWithFile(artifact.getFile(), artifact))
+        .map(artifact -> {
+          if (pomSignatureReplacement != null && isBuildPomSignature(artifact)) {
+            return new ArtifactWithFile(pomSignatureReplacement, artifact);
+          }
+          return new ArtifactWithFile(artifact.getFile(), artifact);
+        })
         .collect(toList());
+  }
+
+  /**
+   * Find the Maven 4 consumer POM among attached artifacts.
+   * Maven 4 attaches it with classifier "consumer" and type "pom".
+   */
+  private Optional<File> findConsumerPom(final MavenProject mavenProject) {
+    for (Artifact artifact : mavenProject.getAttachedArtifacts()) {
+      if (isConsumerPom(artifact)) {
+        return Optional.ofNullable(artifact.getFile());
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static boolean isConsumerPom(final Artifact artifact) {
+    return CONSUMER_CLASSIFIER.equals(artifact.getClassifier())
+        && POM_TYPE.equals(artifact.getType());
+  }
+
+  private static boolean isConsumerPomSignature(final Artifact artifact) {
+    return CONSUMER_CLASSIFIER.equals(artifact.getClassifier())
+        && POM_SIGNATURE_TYPE.equals(artifact.getType());
+  }
+
+  private static boolean isBuildPomSignature(final Artifact artifact) {
+    return (artifact.getClassifier() == null || artifact.getClassifier().isEmpty())
+        && POM_SIGNATURE_TYPE.equals(artifact.getType());
   }
 
   private void deleteMavenMetadataCentralStagingXml(final MavenProject project, final Path sourceDir) {

--- a/src/test/java/org/sonatype/central/publisher/plugin/utils/ProjectUtilsImplConsumerPomTest.java
+++ b/src/test/java/org/sonatype/central/publisher/plugin/utils/ProjectUtilsImplConsumerPomTest.java
@@ -1,0 +1,178 @@
+package org.sonatype.central.publisher.plugin.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
+import org.sonatype.central.publisher.plugin.model.ArtifactWithFile;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.factory.ArtifactFactory;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests that Maven 4 consumer POM is used as the main POM when staging artifacts.
+ *
+ * Maven 4 generates two POMs:
+ * - build POM (mavenProject.getFile()) - contains ${revision}, model 4.1.0, build config
+ * - consumer POM (attached artifact, classifier="consumer", type="pom") - resolved, model 4.0.0
+ *
+ * Central Portal requires the consumer POM as the main .pom file.
+ */
+public class ProjectUtilsImplConsumerPomTest
+{
+
+  @Rule
+  public TemporaryFolder tempDir = new TemporaryFolder();
+
+  private ProjectUtilsImpl projectUtils;
+
+  private ArtifactFactory artifactFactory;
+
+  private File buildPomFile;
+
+  private File consumerPomFile;
+
+  private File jarFile;
+
+  @Before
+  public void setUp() throws IOException {
+    projectUtils = new ProjectUtilsImpl();
+    artifactFactory = mock(ArtifactFactory.class);
+
+    buildPomFile = tempDir.newFile("pom.xml");
+    Files.write(buildPomFile.toPath(), Arrays.asList(
+        "<project xmlns=\"http://maven.apache.org/POM/4.1.0\">",
+        "  <modelVersion>4.1.0</modelVersion>",
+        "  <groupId>io.github.test</groupId>",
+        "  <artifactId>test-app</artifactId>",
+        "  <version>${revision}</version>",
+        "</project>"));
+
+    consumerPomFile = tempDir.newFile("consumer.pom");
+    Files.write(consumerPomFile.toPath(), Arrays.asList(
+        "<project xmlns=\"http://maven.apache.org/POM/4.0.0\">",
+        "  <modelVersion>4.0.0</modelVersion>",
+        "  <groupId>io.github.test</groupId>",
+        "  <artifactId>test-app</artifactId>",
+        "  <version>1.0.0</version>",
+        "</project>"));
+
+    jarFile = tempDir.newFile("test-app-1.0.0.jar");
+  }
+
+  /**
+   * When Maven 4 attaches a consumer POM (classifier="consumer", type="pom"),
+   * the plugin should NOT include it as a separate artifact in the bundle.
+   * Verifies consumer POM is used as main POM and filtered from artifacts.
+   */
+  @Test
+  public void shouldNotIncludeConsumerPomAsSeparateArtifact() throws Exception {
+    MavenProject project = createProject();
+
+    Artifact mainArtifact = createArtifact(null, "jar");
+    mainArtifact.setFile(jarFile);
+    project.setArtifact(mainArtifact);
+
+    // Maven 4 attaches consumer POM with classifier "consumer"
+    Artifact consumerPom = createArtifact("consumer", "pom");
+    consumerPom.setFile(consumerPomFile);
+
+    // GPG plugin creates signature for consumer POM (type "pom.asc")
+    File consumerPomAscFile = tempDir.newFile("consumer.pom.asc");
+    Artifact consumerPomAsc = createArtifact("consumer", "pom.asc");
+    consumerPomAsc.setFile(consumerPomAscFile);
+
+    // GPG plugin creates signature for build POM (type "pom.asc", no classifier)
+    File buildPomAscFile = tempDir.newFile("build.pom.asc");
+    Artifact buildPomAsc = createArtifact(null, "pom.asc");
+    buildPomAsc.setFile(buildPomAscFile);
+
+    File sourcesFile = tempDir.newFile("test-app-1.0.0-sources.jar");
+    Artifact sources = createArtifact("sources", "jar");
+    sources.setFile(sourcesFile);
+
+    project.addAttachedArtifact(consumerPom);
+    project.addAttachedArtifact(consumerPomAsc);
+    project.addAttachedArtifact(buildPomAsc);
+    project.addAttachedArtifact(sources);
+
+    List<ArtifactWithFile> result = projectUtils.getArtifacts(project, artifactFactory);
+
+    // Consumer POM should NOT appear as separate artifact
+    long consumerPomCount = result.stream()
+        .filter(a -> consumerPomFile.equals(a.getFile()))
+        .count();
+    assertThat("Consumer POM should not be a separate artifact in the bundle",
+        consumerPomCount, is(0L));
+
+    // Build POM signature should be replaced with consumer POM signature
+    long buildPomAscCount = result.stream()
+        .filter(a -> buildPomAscFile.equals(a.getFile()))
+        .count();
+    assertThat("Build POM signature should not be in the bundle",
+        buildPomAscCount, is(0L));
+
+    long consumerPomAscCount = result.stream()
+        .filter(a -> consumerPomAscFile.equals(a.getFile()))
+        .count();
+    assertThat("Consumer POM signature should replace build POM signature",
+        consumerPomAscCount, is(1L));
+
+    // Should have: JAR + pom.asc (swapped) + sources = 3
+    assertThat(result, hasSize(3));
+  }
+
+  /**
+   * Without consumer POM (Maven 3 project), behavior should be unchanged.
+   */
+  @Test
+  public void shouldWorkNormallyWithoutConsumerPom() throws Exception {
+    MavenProject project = createProject();
+
+    Artifact mainArtifact = createArtifact(null, "jar");
+    mainArtifact.setFile(jarFile);
+    project.setArtifact(mainArtifact);
+
+    File sourcesFile = tempDir.newFile("sources.jar");
+    Artifact sources = createArtifact("sources", "jar");
+    sources.setFile(sourcesFile);
+
+    project.addAttachedArtifact(sources);
+
+    List<ArtifactWithFile> result = projectUtils.getArtifacts(project, artifactFactory);
+
+    assertThat(result, hasSize(2));
+  }
+
+  private MavenProject createProject() {
+    Model model = new Model();
+    model.setGroupId("io.github.test");
+    model.setArtifactId("test-app");
+    model.setVersion("1.0.0");
+    model.setPackaging("jar");
+    MavenProject project = new MavenProject(model);
+    project.setFile(buildPomFile);
+    return project;
+  }
+
+  private Artifact createArtifact(String classifier, String type) {
+    return new DefaultArtifact(
+        "io.github.test", "test-app", "1.0.0",
+        null, type, classifier, new DefaultArtifactHandler(type));
+  }
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Summary

- Maven 4 generates a **consumer POM** (attached artifact with classifier `consumer`, type `pom`) containing resolved versions and model 4.0.0
- The plugin currently always uses `mavenProject.getFile()` (the **build POM**) which contains unresolved `${revision}` and model 4.1.0
- This causes Maven Central Portal to reject deployments with _"Failed to associate file with coordinates"_ because it cannot parse the 4.1.0 model POM

### The fix

In `ProjectUtilsImpl`:
- Detect consumer POM among attached artifacts
- Use it as `ProjectArtifactMetadata` instead of the build POM
- Filter it from attached artifacts list to prevent it appearing as a separate `-consumer.pom` file in the bundle

Backwards compatible — without consumer POM (Maven 3 projects) behavior is unchanged.

## Test plan

- [x] `shouldNotIncludeConsumerPomAsSeparateArtifact` — verifies consumer POM is used as main POM metadata and filtered from artifacts
- [x] `shouldWorkNormallyWithoutConsumerPom` — verifies Maven 3 backwards compatibility

## Related

- [MNG-8584](https://issues.apache.org/jira/browse/MNG-8584) — Maven4: Central publishing readiness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Maven 4 consumer POM handling: plugin now prefers a consumer POM when present, excludes it from the artifact list, and substitutes consumer-POM signatures for build-POM signatures to avoid duplicate artifacts.

* **Tests**
  * Added tests validating consumer POM detection, artifact filtering, and fallback behavior when absent.
  * Added Mockito inline mock-maker test configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->