### PR TITLE
Integrate changes of original version 0.11.0

### DIFF
--- a/src/main/java/org/sonatype/central/publisher/client/model/DeploymentApiResponse.java
+++ b/src/main/java/org/sonatype/central/publisher/client/model/DeploymentApiResponse.java
@@ -5,6 +5,7 @@
 
 package org.sonatype.central.publisher.client.model;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -19,6 +20,8 @@ public class DeploymentApiResponse
   private List<String> purls;
 
   private Map<String, List<String>> errors;
+
+  private List<String> warnings;
 
   public String getDeploymentId() {
     return deploymentId;
@@ -58,5 +61,13 @@ public class DeploymentApiResponse
 
   public void setErrors(final Map<String, List<String>> errors) {
     this.errors = errors;
+  }
+
+  public List<String> getWarnings() {
+    return warnings == null ? Collections.emptyList() : warnings;
+  }
+
+  public void setWarnings(final List<String> warnings) {
+    this.warnings = warnings;
   }
 }

--- a/src/main/java/org/sonatype/central/publisher/plugin/PublishMojo.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/PublishMojo.java
@@ -672,7 +672,7 @@ public class PublishMojo
     getLog().info("Using credentials from server id " + publishingServerId + " in settings.xml");
 
     AuthData authData = getUserCredentials();
-    getLog().info("Using Usertoken auth, with namecode: " + authData.getUsername());
+    getLog().debug("Using Usertoken auth, with namecode: " + authData.getUsername());
     publisherClient.setAuthProvider(USERTOKEN, DEFAULT_ORGANIZATION_ID,
         authData.getUsername(),
         authData.getPassword());

--- a/src/main/java/org/sonatype/central/publisher/plugin/watcher/DeploymentPublishedWatcherImpl.java
+++ b/src/main/java/org/sonatype/central/publisher/plugin/watcher/DeploymentPublishedWatcherImpl.java
@@ -84,6 +84,7 @@ public class DeploymentPublishedWatcherImpl
           case VALIDATED:
           case PUBLISHING:
             if (waitUntilRequest == WaitUntilRequest.UPLOADED || waitUntilRequest == WaitUntilRequest.VALIDATED) {
+              outputWarnings(status);
               outputWhereToFinishPublishing(waitForDeploymentStateRequest, deploymentId);
               return;
             }
@@ -105,7 +106,13 @@ public class DeploymentPublishedWatcherImpl
     outputTimeout(deploymentId, status);
   }
 
+  private void outputWarnings(final DeploymentApiResponse status) {
+    status.getWarnings().forEach(msg -> getLogger().warn(msg));
+  }
+
   private void outputPublished(final DeploymentApiResponse status) {
+    outputWarnings(status);
+
     StringBuilder successMessage = new StringBuilder();
 
     successMessage


### PR DESCRIPTION
- update java sources from https://repo1.maven.org/maven2/org/sonatype/central/central-publishing-maven-plugin/0.11.0/central-publishing-maven-plugin-0.11.0-sources.jar

- DeploymentApiResponse.java:
  - add property List<String> warnings

- DeploymentPublishedWatcherImpl.java:
  - add log of probable warnings returned from publisher API

- PublishMojo.java:
  - change log level for logging user token auth from info -> debug level

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment warnings are now captured and displayed during the deployment process
  * Warning notifications appear when deployments reach validation or publishing states
  * Enhanced visibility into potential deployment issues provides clearer operational insight
  * Improved feedback helps with issue identification and deployment management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->