### PR TITLE
Update central-publishing-maven-plugin version to 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -652,7 +652,7 @@
 
         <!-- Sonatype Maven Central Publishing Plugin GAVs -->
         <groupId.central-publishing-maven-plugin.released>io.github.mavenplugins</groupId.central-publishing-maven-plugin.released>
-        <version.central-publishing-maven-plugin.released>1.2.0</version.central-publishing-maven-plugin.released>
+        <version.central-publishing-maven-plugin.released>1.3.0</version.central-publishing-maven-plugin.released>
         <groupId.central-publishing-maven-plugin.forStaging>${groupId.central-publishing-maven-plugin.released}</groupId.central-publishing-maven-plugin.forStaging>
         <version.central-publishing-maven-plugin.forStaging>${version.central-publishing-maven-plugin.released}</version.central-publishing-maven-plugin.forStaging>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Central Publishing Maven Plugin to version 1.3.0 for release publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->